### PR TITLE
Add an option to filter warnings about compling to JS

### DIFF
--- a/lib/linter.dart
+++ b/lib/linter.dart
@@ -53,8 +53,10 @@ final Map<String, String> _severityMap = {
 
 String _infosPrefPath = '${pluginId}.showInfos';
 String _todosPrefPath = '${pluginId}.showTodos';
-String _filterUnnamedWarningPath = '${pluginId}.showUnnamedLibraryWarning';
+String _filterUnnamedLibraryWarningsPath = '${pluginId}.filterUnnamedLibraryWarnings';
+String _filterCompiledToJSWarningsPath = '${pluginId}.filterCompiledToJSWarnings';
 
 bool _shouldShowInfoMessages() => atom.config.get(_infosPrefPath);
 bool _shouldShowTodosMessages() => atom.config.get(_todosPrefPath);
-bool _filterUnnamedLibraryWarnings() => atom.config.get(_filterUnnamedWarningPath);
+bool _shouldFilterUnnamedLibraryWarnings() => atom.config.get(_filterUnnamedLibraryWarningsPath);
+bool _shouldFilterCompiledToJSWarnings() => atom.config.get(_filterCompiledToJSWarningsPath);

--- a/lib/linter/dart_linter_consumer.dart
+++ b/lib/linter/dart_linter_consumer.dart
@@ -22,9 +22,13 @@ class DartLinterConsumer extends LinterConsumer with Disposables {
       if (!_shouldShowTodosMessages()) {
         sortedErrors = sortedErrors.where((issue) => issue.type != 'TODO');
       }
-      if (_filterUnnamedLibraryWarnings()) {
+      if (_shouldFilterUnnamedLibraryWarnings()) {
         sortedErrors = sortedErrors.where(
             (issue) => !issue.message.contains('cannot both be unnamed'));
+      }
+      if (_shouldFilterCompiledToJSWarnings()) {
+        sortedErrors = sortedErrors.where(
+            (issue) => !issue.message.contains('When compiled to JS'));
       }
 
       var formattedErrors = sortedErrors

--- a/lib/plugin.dart
+++ b/lib/plugin.dart
@@ -153,9 +153,15 @@ class AtomDartPackage extends AtomPackage {
         'type': 'boolean',
         'default': false
       },
-      'showUnnamedLibraryWarning': {
+      'filterUnnamedLibraryWarnings': {
         'title': 'Filter unnamed library warnings',
-        'description': 'Filter all unnamed library warnings.',
+        'description': 'Don\'t display warnings about unnamed libraries.',
+        'type': 'boolean',
+        'default': true
+      },
+      'filterCompiledToJSWarnings': {
+        'title': 'Filter warnings about compiling to JavaScript',
+        'description': 'Don\'t display warnings about compiling to JavaScript.',
         'type': 'boolean',
         'default': true
       }


### PR DESCRIPTION
Some Dart projects won't be compiled to JavaScript, which means these warnings
are just spam. For example, projects that depend on dart:sky won't be compiled
to JavaScript because dart:sky cannot be compiled to JavaScript.

Example warning: "When compiled to JS, this test might return true when the left hand side is an int"