### PR TITLE
Automate release tagging for package.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,4 +11,5 @@ dependencies:
 dev_dependencies:
   grinder: ^0.7.0
   html: ^0.12.0
+  pub_semver: ^1.2.1
   test: ^0.12.0

--- a/tool/deploy.dart
+++ b/tool/deploy.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:grinder/grinder.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+main(List args) => grind(args);
+
+@DefaultTask('Deploy software')
+deploy() {
+  deployIt();
+}
+
+deployIt() {
+  // TODO: command line parsing (major, minor, patch) version update
+  // Comment out the if statements while developing this task.
+  var diffResult = Process.runSync("git", ["diff", "--shortstat"]);
+  if (diffResult.stdout.toString().isNotEmpty)
+    throw 'Index is dirty; commit files and try again';
+
+  var syncResult = Process.runSync("git", ["rev-list", "origin..HEAD"]);
+  if (syncResult.stdout.toString().isNotEmpty)
+    throw 'Not synchronized with master; git push and try again';
+
+  var packageFileData = new File('package.json').readAsStringSync();
+  var yamlFileData    = new File('pubspec.yaml').readAsStringSync();
+  var changelogData   = new File('CHANGELOG.md').readAsStringSync();
+
+  var packageData = JSON.decode(packageFileData);
+
+  var currentVersion = new Version.parse(packageData['version']);
+  // TODO: have this match the parameter passed in on the command line
+  var nextVersion = currentVersion.nextPatch;
+
+  var jsonPattern         = (version) => '"version": "${version}"';
+  var yamlPattern         = (version) => 'version: ${version}';
+  var changelogPattern    = (version) => "# ${version}"
+  // We do pattern matches to preserve the formatting in the existing files.
+
+  var newPackageFileData =
+    packageFileData.replaceFirst(jsonPattern(currentVersion),
+      jsonPattern(nextVersion));
+  var newYamlFileData =
+    yamlFileData.replaceFirst(yamlPattern(currentVersion),
+      yamlPattern(nextVersion));
+  var newChangelogData =
+    changelogData.replaceFirst(changelogPattern('Upcoming Version'),
+      changelogPattern(nextVersion));
+
+  new File('package.json').writeAsStringSync(newPackageFileData);
+  new File('pubspec.yaml').writeAsStringSync(newYamlFileData);
+  new File('CHANGELOG.md').writeAsStringSync(newChangelogData);
+
+  Process.runSync("git", ["commit", "-a", '-m "prepare $nextVersion"']);
+  Process.runSync("git", ["tag", nextVersion.toString()]);
+  Process.runSync("git", ["push", "-t"]);
+  Process.runSync("apm", ["publish", "-t", nextVersion.toString()]);
+
+  print("Version ${nextVersion} has been prepared!");
+  print('¯\\_(ツ)_/¯');
+}

--- a/tool/deploy.dart
+++ b/tool/deploy.dart
@@ -56,6 +56,6 @@ deployIt() {
   Process.runSync("git", ["push", "-t"]);
   Process.runSync("apm", ["publish", "-t", nextVersion.toString()]);
 
-  print("Version ${nextVersion} has been prepared!");
+  print("Version ${nextVersion} has been published!");
   print('¯\\_(ツ)_/¯');
 }

--- a/tool/deploy.dart
+++ b/tool/deploy.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:grinder/grinder.dart';
@@ -33,7 +34,7 @@ deployIt() {
 
   var jsonPattern         = (version) => '"version": "${version}"';
   var yamlPattern         = (version) => 'version: ${version}';
-  var changelogPattern    = (version) => "# ${version}"
+  var changelogPattern    = (version) => "# ${version}";
   // We do pattern matches to preserve the formatting in the existing files.
 
   var newPackageFileData =

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -5,8 +5,17 @@
 library atom.grind;
 
 import 'dart:io';
+import 'dart:convert';
+
 
 import 'package:grinder/grinder.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+part "publish.dart";
+
+// crashes grinder -- so add it as a library dependency for now.
+// import 'deploy.dart' show deploy;
+// export 'publish.dart' show deploy;
 
 main(List args) => grind(args);
 

--- a/tool/publish.dart
+++ b/tool/publish.dart
@@ -1,17 +1,14 @@
-import 'dart:convert';
-import 'dart:io';
+part of atom.grind;
 
-import 'package:grinder/grinder.dart';
-import 'package:pub_semver/pub_semver.dart';
+// import 'dart:convert';
+// import 'dart:io';
 
-main(List args) => grind(args);
+// import 'package:grinder/grinder.dart';
+// import 'package:pub_semver/pub_semver.dart';
 
-@DefaultTask('Deploy software')
-deploy() {
-  deployIt();
-}
-
-deployIt() {
+@Task('Publish a new version of dartlang')
+publish() {
+  throw 'Sorry -- grinder does not yet support specifying options on the command line!';
   // TODO: command line parsing (major, minor, patch) version update
   // Comment out the if statements while developing this task.
   var diffResult = Process.runSync("git", ["diff", "--shortstat"]);


### PR DESCRIPTION
Majority of the work for #49.

@devoncarew 

I normally use Rake, so my knowledge of Grinder is pretty limited. The logic works fine, but it's hard-coded to "nextPatch" instead of accepting a command line parameter. You'll probably want to tweak the changelog pattern / output text, too.