### PR TITLE
Improve some grammar highlighting

### DIFF
--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -165,8 +165,10 @@
         'name': 'support.class.dart'
       }
       {
-        'match': '(_?[a-z][a-zA-Z]+)(?=\\\(\\\[)'
-        'name': 'entity.name.function.dart'
+        'match': '(_?[a-z][a-zA-Z0-9]+)\\('
+        'captures':
+          '1':
+            'name': 'entity.name.function.dart'
       }
       {
         'match': '\\b[A-Z_0-9]+\\b'

--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -254,7 +254,7 @@
         'name': 'storage.modifier.dart'
       }
       {
-        'match': '\\b(?:void|bool|num|int|double|dynamic|var|String)\\b'
+        'match': '\\b(?:void|bool|num|int|double|dynamic|var)\\b'
         'name': 'storage.type.primitive.dart'
       }
     ]


### PR DESCRIPTION
Makes function highlighting more consistent. Also removed `String` from primitives as that will be highlighted by the class highlighting rule.