### PR TITLE
Don't show custom errors pane if it is disabled in settings

### DIFF
--- a/lib/impl/errors.dart
+++ b/lib/impl/errors.dart
@@ -37,7 +37,7 @@ class ErrorsController implements Disposable {
 
     enabled = atom.config.getValue(_errorPref);
 
-    view = new ErrorsView();
+    view = new ErrorsView(enabled);
     statusElement = new ErrorsStatusElement(this, enabled);
 
     onProcessedErrorsChanged.listen(_handleErrorsChanged);
@@ -121,7 +121,7 @@ class ErrorsView extends AtomView {
   CoreElement countElement;
   CoreElement focusElement;
 
-  ErrorsView() : super('Errors', classes: 'errors-view dartlang', prefName: 'Errors',
+  ErrorsView(bool enabled) : super('Errors', classes: 'errors-view dartlang', prefName: 'Errors',
       rightPanel: false, cancelCloses: false, showTitle: false) {
     //root.toggleClass('tree-view', false);
 
@@ -132,6 +132,8 @@ class ErrorsView extends AtomView {
         focusElement = div(c: 'badge focus-title')
       ])
     ]);
+
+    state['errorViewShowing'] = enabled;
 
     bool hidden = state['errorViewShowing'] == false;
     hidden ? hide() : show();


### PR DESCRIPTION
It is quite annoying to see opened errors pane with "No issues" label for non-dart or even for dart projects on the first editor launch.