### PR TITLE
redux of linux keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - added a setting to enable analysis for DEP 34 - less restricted mixins.
 - fixed an issue with the `linter` plugin where info level issues were named `Trace`
 - fixed an style / clipping issue in the problems view
+- new and updated keybindings! Why the changes? So many, many conflicts on
+  various platforms. The latest is: `f4` is `type hierarchy`, `ctrl-f4` (or
+  `cmd-f4) is `find references`, and `ctrl-alt-down` (or `alt-cmd-down`) is
+  `jump to declaration`.
 
 ## 0.4.7
 - filtered 'potential' edits from rename refactorings

--- a/keymaps/atom-dart.cson
+++ b/keymaps/atom-dart.cson
@@ -16,26 +16,25 @@
   'ctrl-1': 'dartlang:quick-fix'
   'alt-enter': 'dartlang:quick-fix'
   'f1': 'dartlang:show-dartdoc'
-  'f3': 'dartlang:jump-to-declaration'
   'f4': 'dartlang:type-hierarchy'
   'alt-shift-r': 'dartlang:refactor-rename'
   'enter': 'dartlang:newline'
 
 # Dart editor commands (mac)
 'body.platform-darwin atom-text-editor[data-grammar~="dart"]:not([mini])':
+  'f3': 'dartlang:jump-to-declaration'
+  'cmd-f4': 'dartlang:find-references'
   'cmd-r': 'dartlang:run-application-configuration'
   'cmd-shift-r': 'dartlang:run-application'
   'cmd-alt-b': 'dartlang:dart-format'
   'cmd-alt-o': 'dartlang:organize-directives'
-  'shift-cmd-g': 'dartlang:find-references'
-
-# '.tree-view span[data-path]':
-#   'cmd-r': 'dartlang:run-application'
+  'alt-cmd-down': 'dartlang:jump-to-declaration'
 
 # Dart editor commands (windows and linux)
 'body.platform-linux atom-text-editor[data-grammar~="dart"]:not([mini]), body.platform-win32 atom-text-editor[data-grammar~="dart"]:not([mini])':
-  'ctrl-r': 'dartlang:run-apapplicationp-configuration'
+  'ctrl-f4': 'dartlang:find-references'
+  'ctrl-r': 'dartlang:run-application-configuration'
   'ctrl-shift-r': 'dartlang:run-application'
   'ctrl-alt-b': 'dartlang:dart-format'
   'ctrl-alt-o': 'dartlang:organize-directives'
-  'ctrl-shift-g': 'dartlang:find-references'
+  'ctrl-alt-down': 'dartlang:jump-to-declaration'

--- a/web/entry.dart.js
+++ b/web/entry.dart.js
@@ -29789,7 +29789,7 @@ self.getTextEditorForElement = function(element) { return element.o.getModel(); 
       "^": "Closure:0;_captured_version_1",
       call$1: [function(value) {
         var t1, t2, str, t3, screenWidth, screenHeight;
-        if (J.$eq$(C.JSString_methods.startsWith$1("UA-000000-0", "UA-0000") ? false : value, true)) {
+        if (J.$eq$(C.JSString_methods.startsWith$1("UA-26406144-22", "UA-0000") ? false : value, true)) {
           t1 = this._captured_version_1;
           t2 = new V.HtmlPersistentProperties(null, "dartlang");
           str = window.localStorage.getItem("dartlang");
@@ -29797,7 +29797,7 @@ self.getTextEditorForElement = function(element) { return element.o.getModel(); 
           t3 = new Z.ThrottlingBucket(20, null, null);
           t3.drops = 20;
           t3._lastReplenish = Date.now();
-          t3 = new L.AnalyticsHtml("UA-000000-0", t2, new V.HtmlPostHandler(null), t3, P.LinkedHashMap__makeEmpty(), [], null);
+          t3 = new L.AnalyticsHtml("UA-26406144-22", t2, new V.HtmlPostHandler(null), t3, P.LinkedHashMap__makeEmpty(), [], null);
           t3.setSessionValue$2("an", "dartlang");
           if (t1 != null)
             t3.setSessionValue$2("av", t1);


### PR DESCRIPTION
- redux of the keybindings: `f4` is `type hierarchy`, `ctrl-f4` (or `cmd-f4) is `find references`, and `ctrl-alt-down` (or `alt-cmd-down`) is `jump to declaration` (fix https://github.com/dart-atom/dartlang/issues/375)

