### PR TITLE
fix an issues with editing in c-style comments

### DIFF
--- a/lib/impl/editing.dart
+++ b/lib/impl/editing.dart
@@ -104,7 +104,8 @@ bool _handleEnterKey(TextEditor editor, int row, int col) {
   if (trimmedText.endsWith('*/') && atEol) {
     editor.atomic(() {
       editor.insertNewline();
-      editor.backspace();
+      // Only back up if we had some indentation on the current line.
+      if (line != trimmedText) editor.backspace();
     });
     return true;
   }


### PR DESCRIPTION
From a user report:

> if you have a C-style multi-line comment /*  */ and the final */ starts at the first character of the line, you can't hit return if the cursor is at the end of that line, and get a newline

@krisgiesing