### PR TITLE
fix syntax highlighting issues with dartdoc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - when opening a directory with multiple projects, we now notify if pub needs to
   be run for each project
 - fixed a regression with jump-to-declaration
+- fixed syntax highlighting issues with dartdoc comments
 
 ## 0.4.12
 - fixed an issue when editing in c-style comments

--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -72,12 +72,6 @@
       {
         'match': '(\\*    .*)$'
       }
-      {
-        'match': '((    ).*)$'
-        'captures':
-          '1':
-            'name': 'variable.other.source.dart'
-      }
     ]
   'comments':
     'patterns': [
@@ -113,6 +107,14 @@
     ]
   'comments-doc':
     'patterns': [
+      {
+        'match': '(///)     (.*?)$'
+        'captures':
+          '1':
+            'name': 'comment.block.triple-slash.dart'
+          '2':
+            'name': 'variable.other.source.dart'
+      }
       {
         'match': '(///) (.*?)$'
         'captures':


### PR DESCRIPTION
Fix https://github.com/dart-atom/dartlang/issues/464 - fix some highlighting issues with dartdoc comments.