### PR TITLE
fix a syntax highlighting issue for escaped chars in strings

### DIFF
--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -307,7 +307,7 @@
         'name': 'string.quoted.triple.single.dart'
       }
       {
-        'begin': '(?<!\\\\|r)"'
+        'begin': '(?<!\\|r)"'
         'end': '"'
         'name': 'string.interpolated.double.dart'
         'patterns': [


### PR DESCRIPTION
Fix https://github.com/dart-atom/dartlang/issues/418 - a syntax highlighting issue for escaped chars in strings.