### PR TITLE
update the keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 - fixed a NPE related to determining whether files are executable
+- bound `jump-to-declaration` to `ctrl-alt-enter` on windows
 
 ## 0.4.15
 - create hyperlinks from exception traces in the console view

--- a/keymaps/atom-dart.cson
+++ b/keymaps/atom-dart.cson
@@ -33,17 +33,21 @@
 
 # Dart editor commands (mac)
 'body.platform-darwin atom-text-editor[data-grammar~="dart"]:not([mini])':
-  'f3': 'dartlang:jump-to-declaration'
   'cmd-f4': 'dartlang:find-references'
   'cmd-r': 'dartlang:run-application'
   'cmd-alt-b': 'dartlang:dart-format'
   'cmd-alt-o': 'dartlang:organize-directives'
-  'alt-cmd-down': 'dartlang:jump-to-declaration'
+  'cmd-alt-down': 'dartlang:jump-to-declaration'
+  'cmd-alt-enter': 'dartlang:jump-to-declaration'
 
 # Dart editor commands (windows and linux)
 'body.platform-linux atom-text-editor[data-grammar~="dart"]:not([mini]), body.platform-win32 atom-text-editor[data-grammar~="dart"]:not([mini])':
+  'ctrl-alt-enter': 'dartlang:jump-to-declaration'
   'ctrl-f4': 'dartlang:find-references'
   'ctrl-r': 'dartlang:run-application'
   'ctrl-alt-b': 'dartlang:dart-format'
   'ctrl-alt-o': 'dartlang:organize-directives'
+
+# Dart editor commands (linux)
+'body.platform-linux atom-text-editor[data-grammar~="dart"]:not([mini])':
   'ctrl-alt-down': 'dartlang:jump-to-declaration'


### PR DESCRIPTION
fix https://github.com/dart-atom/dartlang/issues/532

Use `ctrl-alt-enter` for jump-to-declaration on windows, and that and `ctrl-alt-down` on mac+linux.