### PR TITLE
fix an npe when removing a dart project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added an analysis server section to the plugin status view
 - add inline local refactoring
 - move extract and inline local refactorings into submenu
+- fixed an exception when removing a Dart project
 
 ## 0.4.16
 - re-worked the UI for the errors, console, type hierarchy, and find references

--- a/lib/js.dart
+++ b/lib/js.dart
@@ -90,8 +90,9 @@ class ProxyHolder {
 
   Stream eventStream(String eventName) {
     Disposable disposable;
+
     StreamController controller = new StreamController.broadcast(
-        onCancel: () => disposable.dispose());
+        onCancel: () => disposable?.dispose());
 
     try {
       disposable = new JsDisposable(

--- a/lib/launch/launch_configs.dart
+++ b/lib/launch/launch_configs.dart
@@ -243,7 +243,7 @@ class _ProjectConfigurations implements Disposable {
   StreamSubscription _sub;
 
   _ProjectConfigurations(this.projectPath, this.launchDir) {
-    _sub = launchDir.onDidChange.listen((_) => _configs = null);
+    _listenToLaunchDir();
   }
 
   List<LaunchConfiguration> getConfigs() {
@@ -268,10 +268,18 @@ class _ProjectConfigurations implements Disposable {
     } else {
       file.create().then((_) {
         file.writeSync(contents);
+
+        _listenToLaunchDir();
       });
     }
 
     return new LaunchConfiguration._parse(projectPath, file, contents);
+  }
+
+  void _listenToLaunchDir() {
+    if (_sub == null && launchDir.existsSync()) {
+      _sub = launchDir.onDidChange.listen((_) => _configs = null);
+    }
   }
 
   void _reparse() {
@@ -291,6 +299,6 @@ class _ProjectConfigurations implements Disposable {
   }
 
   void dispose() {
-    _sub.cancel();
+    _sub?.cancel();
   }
 }


### PR DESCRIPTION
- fix an npe when removing a dart project. The first time a launch was created for a project, the `.atom/launch` directory doesn't exist. The file watching code was failing in these situations, and when later removing the dart project, we got an NPE from a dispose method.
- fix https://github.com/dart-atom/dartlang/issues/611

@danrubel 