### PR TITLE
Use full URL for screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package is a full-featured Dart development plugin for Atom. It supports
 features like auto-discovery of the Dart SDK, errors and warnings shown as you
 type, code completion, refactorings, and integration with Pub and other tools.
 
-![Dart plugin for Atom screenshot](assets/dart-plugin-atom-screenshot.png)
+![Dart plugin for Atom screenshot](https://raw.githubusercontent.com/dart-atom/dartlang/master/assets/dart-plugin-atom-screenshot.png)
 
 ## Installing
 


### PR DESCRIPTION
Replaced relative with full URL for the screenshot in the README to make it visible on https://atom.io/packages/dartlang

(Currently it shows a broken image.)