### PR TITLE
do not hardcode enableSuperMixins - fixes #677

### DIFF
--- a/lib/analysis_server.dart
+++ b/lib/analysis_server.dart
@@ -436,9 +436,8 @@ class _AnalysisServerWrapper extends Server {
     _executables.clear();
     execution.setSubscriptions(['LAUNCH_DATA']);
 
-    // Tracking `enableSuperMixins` here: github.com/dart-lang/sdk/issues/23772.
     analysis.updateOptions(new AnalysisOptions(
-      //enableSuperMixins: true
+      // override Analysis Server defaults here
     ));
 
     server.getVersion().then((v) => _logger.info('version ${v.version}'));

--- a/lib/analysis_server.dart
+++ b/lib/analysis_server.dart
@@ -438,7 +438,7 @@ class _AnalysisServerWrapper extends Server {
 
     // Tracking `enableSuperMixins` here: github.com/dart-lang/sdk/issues/23772.
     analysis.updateOptions(new AnalysisOptions(
-      enableSuperMixins: true
+      //enableSuperMixins: true
     ));
 
     server.getVersion().then((v) => _logger.info('version ${v.version}'));

--- a/lib/analysis_server.dart
+++ b/lib/analysis_server.dart
@@ -436,10 +436,6 @@ class _AnalysisServerWrapper extends Server {
     _executables.clear();
     execution.setSubscriptions(['LAUNCH_DATA']);
 
-    analysis.updateOptions(new AnalysisOptions(
-      // override Analysis Server defaults here
-    ));
-
     server.getVersion().then((v) => _logger.info('version ${v.version}'));
     server.onStatus.listen((ServerStatus status) {
       if (status.analysis != null) {


### PR DESCRIPTION
@devoncarew do not hardcode enableSuperMixins now that analysis server supports enableSuperMixins in _embedded.yaml and .analysis_options