### PR TITLE
Permits to filter errors on different scope level

### DIFF
--- a/styles/errors.less
+++ b/styles/errors.less
@@ -4,10 +4,6 @@
   .button-bar {
     //background-color: @tree-view-background-color;
 
-    .focus-title {
-      display: inline-block;
-    }
-
     .errors-count {
       display: inline-block;
     }
@@ -15,6 +11,11 @@
     .badge {
       margin-left: 5px;
       cursor: default;
+    }
+
+    .focus-title {
+      display: inline-block;
+      cursor: pointer;
     }
   }
 


### PR DESCRIPTION
**Context**
On middle size to large size projects, the errors views can have too much information of directory/files the developper is not currently working on.

**PR approach**
This PR gives the ability to switch scope: 
 - Errors in the whole project(default)
 - Errors in the file selected in the editor.
 - Errors in a custom directory.

Possible enhancement:
 - Use a regex instead of a custom directory path, that would allow power user to do more customization.
 - Also filter errors in the `DartLinterConsumer` so we can receive data hidden because of the cap. (Or remove the cap and put it in the `ErrorController`)
- Save this options by project.

This PR is mainly a first attempt to have feedback.