### PR TITLE
use isolate runnable info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - when trying to auto-locate the Dart SDK, use $FLUTTER_ROOT/bin/cache/dart-sdk
   as one of the places to look
 - added a `flutter doctor` command
+- fix an issue where we could send breakpoints in before the VM was ready to
+  receive them
 
 ## 0.6.0
 - added a toolbar to show runnable applications and available devices

--- a/lib/debug/observatory_debugger.dart
+++ b/lib/debug/observatory_debugger.dart
@@ -346,7 +346,6 @@ class ObservatoryConnection extends DebugConnection {
         _installBreakpoints(ref);
       }
     }).then((_) {
-      // TODO: We should only call this when breakpoints have been set.
       isolate._isolateInitializedCompleter.complete();
 
       if (isolate.isolate.pauseEvent.kind == EventKind.kPauseStart) {


### PR DESCRIPTION
- fix an issue where we could send breakpoints in before the VM was ready to receive them
- fix https://github.com/dart-atom/dartlang/issues/736

@danrubel 