### PR TITLE
refactor dartlang to use atom.dart fs

### DIFF
--- a/lib/analysis/references.dart
+++ b/lib/analysis/references.dart
@@ -6,11 +6,11 @@ import 'dart:collection';
 import 'dart:html' as html show DivElement, Element, SpanElement;
 import 'dart:math' as math;
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import '../analysis_server.dart';
 import '../atom.dart';
-import '../atom_utils.dart';
 import '../elements.dart';
 import '../state.dart';
 import '../utils.dart';
@@ -195,7 +195,7 @@ class FindReferencesView extends View {
     List<String> relPath = atom.project.relativizePath(originalPath);
     if (relPath[0] != null) {
       String base = relPath[0];
-      int index = base.lastIndexOf(separator);
+      int index = base.lastIndexOf(fs.separator);
       if (index != -1) base = base.substring(index + 1);
       return [base, relPath[1]];
     }
@@ -250,9 +250,9 @@ class FindReferencesView extends View {
   //   job.schedule();
   // }
 
-  static final _cachePrefix = '${separator}.pub-cache${separator}';
-  static final _pubPrefix = 'hosted${separator}pub.dartlang.org${separator}';
-  static final _libPrefix = '${separator}lib${separator}';
+  static final _cachePrefix = '${fs.separator}.pub-cache${fs.separator}';
+  static final _pubPrefix = 'hosted${fs.separator}pub.dartlang.org${fs.separator}';
+  static final _libPrefix = '${fs.separator}lib${fs.separator}';
 }
 
 class _MatchParser {

--- a/lib/atom.dart
+++ b/lib/atom.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A Dart wrapper around the [Atom](https://atom.io/docs/api) apis.
-library atom2;
 
 import 'dart:async';
 import 'dart:html' hide File, Notification, Point;

--- a/lib/atom.dart
+++ b/lib/atom.dart
@@ -3,12 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A Dart wrapper around the [Atom](https://atom.io/docs/api) apis.
-library atom;
+library atom2;
 
 import 'dart:async';
 import 'dart:html' hide File, Notification, Point;
 import 'dart:js';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import 'js.dart';
@@ -632,97 +633,6 @@ class Project extends ProxyHolder {
   bool contains(String pathToCheck) => invoke('contains', pathToCheck);
 }
 
-abstract class Entry extends ProxyHolder {
-  Entry(JsObject object) : super(object);
-
-  /// Fires an event when the file or directory's contents change.
-  Stream get onDidChange => eventStream('onDidChange');
-
-  String get path => obj['path'];
-
-  bool isFile() => invoke('isFile');
-  bool isDirectory() => invoke('isDirectory');
-  bool existsSync() => invoke('existsSync');
-
-  String getBaseName() => invoke('getBaseName');
-  String getPath() => invoke('getPath');
-  String getRealPathSync() => invoke('getRealPathSync');
-
-  Directory getParent() => new Directory(invoke('getParent'));
-
-  String toString() => path;
-}
-
-class File extends Entry {
-  File(JsObject object) : super(object);
-  File.fromPath(String path, [bool symlink]) :
-      super(_create('File', path, symlink));
-
-  /// Creates the file on disk that corresponds to [getPath] if no such file
-  /// already exists.
-  Future create() => promiseToFuture(invoke('create'));
-
-  Stream get onDidRename => eventStream('onDidRename');
-  Stream get onDidDelete => eventStream('onDidDelete');
-
-  /// Get the SHA-1 digest of this file.
-  String getDigestSync() => invoke('getDigestSync');
-
-  String getEncoding() => invoke('getEncoding');
-
-  /// Reads the contents of the file. [flushCache] indicates whether to require
-  /// a direct read or if a cached copy is acceptable.
-  Future<String> read([bool flushCache]) =>
-      promiseToFuture(invoke('read', flushCache));
-
-  /// Reads the contents of the file. [flushCache] indicates whether to require
-  /// a direct read or if a cached copy is acceptable.
-  String readSync([bool flushCache]) => invoke('readSync', flushCache);
-
-  /// Overwrites the file with the given text.
-  void writeSync(String text) => invoke('writeSync', text);
-
-  int get hashCode => path.hashCode;
-
-  operator==(other) => other is File && path == other.path;
-}
-
-class Directory extends Entry {
-  Directory(JsObject object) : super(object);
-  Directory.fromPath(String path, [bool symlink]) :
-      super(_create('Directory', path, symlink));
-
-  /// Creates the directory on disk that corresponds to [getPath] if no such
-  /// directory already exists. [mode] defaults to `0777`.
-  Future create([int mode]) => promiseToFuture(invoke('create', mode));
-
-  /// Returns `true` if this [Directory] is the root directory of the
-  /// filesystem, or `false` if it isn't.
-  bool isRoot() => invoke('isRoot');
-
-  // TODO: Should we move this _cvt guard into the File and Directory ctors?
-  File getFile(filename) => new File(_cvt(invoke('getFile', filename)));
-
-  Directory getSubdirectory(String dirname) =>
-      new Directory(invoke('getSubdirectory', dirname));
-
-  List<Entry> getEntriesSync() {
-    return invoke('getEntriesSync').map((entry) {
-      entry = _cvt(entry);
-      return entry.callMethod('isFile') ? new File(entry) : new Directory(entry);
-    }).toList();
-  }
-
-  /// Returns whether the given path (real or symbolic) is inside this directory.
-  /// This method does not actually check if the path exists, it just checks if
-  /// the path is under this directory.
-  bool contains(String p) => invoke('contains', p);
-
-  int get hashCode => path.hashCode;
-
-  operator==(other) => other is Directory && path == other.path;
-}
-
 /// This cooresponds to an `atom-text-editor` custom element.
 class TextEditorView extends ProxyHolder {
   TextEditorView(JsObject object) : super(_cvt(object));
@@ -1271,22 +1181,8 @@ JsObject _cvt(JsObject object) {
   return new JsObject.fromBrowserObject(object);
 }
 
-Stats statSync(String path) => new Stats(_fs.callMethod('statSync', [path]));
-
-bool existsSync(String path) => _fs.callMethod('existsSync', [path]);
-
 /// Returns the operating system's default directory for temp files.
 String tmpdir() => _os.callMethod('tmpdir');
 
 // TODO(devoncarew): [homedir] can throw (or isn't available?) on some platforms.
 String homedir() => _os.callMethod('homedir');
-
-class Stats extends ProxyHolder {
-  Stats(JsObject obj) : super(obj);
-
-  bool isFile() => invoke('isFile');
-  bool isDirectory() => invoke('isDirectory');
-
-  // The last modified time (`2015-10-08 17:48:42.000`).
-  String get mtime => obj['mtime'];
-}

--- a/lib/atom_utils.dart
+++ b/lib/atom_utils.dart
@@ -10,6 +10,7 @@ import 'dart:html' show DivElement, Element, HttpRequest, Node, NodeValidator,
     NodeTreeSanitizer, window;
 import 'dart:js';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import 'atom.dart';
@@ -32,43 +33,20 @@ final bool isWindows = platform.startsWith('win');
 final bool isMac = platform == 'darwin';
 final bool isLinux = !isWindows && !isMac;
 
-final String separator = isWindows ? r'\' : '/';
-
-String join(dir, String arg1, [String arg2, String arg3]) {
-  if (dir is Directory) dir = dir.path;
-  String path = '${dir}${separator}${arg1}';
-  if (arg2 != null) {
-    path = '${path}${separator}${arg2}';
-    if (arg3 != null) path = '${path}${separator}${arg3}';
-  }
-  return path;
-}
-
-/// Return the parent of the given file path or entry.
-String dirname(entry) {
-  if (entry is Entry) return entry.getParent().path;
-  int index = entry.lastIndexOf(separator);
-  return index == -1 ? null : entry.substring(0, index);
-}
-
 /// Return the name of the file for the given path.
 String basename(String path) {
-  if (path.endsWith(separator)) path = path.substring(0, path.length - 1);
-  int index = path.lastIndexOf(separator);
+  if (path.endsWith(fs.separator)) path = path.substring(0, path.length - 1);
+  int index = path.lastIndexOf(fs.separator);
   return index == -1 ? path : path.substring(index + 1);
 }
 
 String relativize(String root, String path) {
   if (path.startsWith(root)) {
     path = path.substring(root.length);
-    if (path.startsWith(separator)) path = path.substring(1);
+    if (path.startsWith(fs.separator)) path = path.substring(1);
   }
   return path;
 }
-
-/// Relative path entries are removed and symlinks are resolved to their final
-/// destination.
-String realpathSync(String path) => _fs.callMethod('realpathSync', [path]);
 
 /// Get the value of an environment variable. This is often not accurate on the
 /// mac since mac apps are launched in a different shell then the terminal

--- a/lib/dartino/dartino_util.dart
+++ b/lib/dartino/dartino_util.dart
@@ -1,7 +1,8 @@
 library atom.dartino.dartino_util;
 
+import 'package:atom/node/fs.dart';
+
 import '../atom.dart';
-import '../atom_utils.dart';
 
 const _pluginId = 'dartino';
 
@@ -16,14 +17,14 @@ class _Dartino {
   bool hasSdk() => sdkPath().isNotEmpty;
 
   bool isProject(projDir) =>
-      hasSdk() && existsSync(join(projDir, 'dartino.yaml'));
+      hasSdk() && fs.existsSync(fs.join(projDir, 'dartino.yaml'));
 
   /// If the project does *not* contain a .packages file
   /// then return the SDK defined package spec file
   /// so that it can be passed to the analysis server for this project
   /// otherwise return `null`.
   String packageRoot(projDir) {
-    if (existsSync(join(projDir, '.packages'))) return null;
-    return join(sdkPath(), 'internal', 'dartino-sdk.packages');
+    if (fs.existsSync(fs.join(projDir, '.packages'))) return null;
+    return fs.join(sdkPath(), 'internal', 'dartino-sdk.packages');
   }
 }

--- a/lib/debug/breakpoints.dart
+++ b/lib/debug/breakpoints.dart
@@ -2,6 +2,7 @@ library atom.breakpoints;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import '../atom.dart';
@@ -189,7 +190,7 @@ class AtomBreakpoint implements Comparable {
   }
 
   /// Return whether the file associated with this breakpoint exists.
-  bool fileExists() => existsSync(path);
+  bool fileExists() => fs.existsSync(path);
 
   void updateLocation(LineColumn lineCol) {
     _line = lineCol.line;

--- a/lib/debug/debugger_ui.dart
+++ b/lib/debug/debugger_ui.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:html' show Element;
 import 'dart:js' show context, JsFunction;
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import '../atom.dart';
@@ -204,7 +205,7 @@ class DebuggerView extends View {
   }
 
   void _jumpToLocation(DebugLocation location, {bool addExecMarker: false}) {
-    if (!existsSync(location.path)) {
+    if (!fs.existsSync(location.path)) {
       atom.notifications.addWarning("Cannot find file '${location.path}'.");
       return;
     }

--- a/lib/debug/observatory_debugger.dart
+++ b/lib/debug/observatory_debugger.dart
@@ -3,6 +3,7 @@ library atom.observatory_debugger;
 import 'dart:async';
 import 'dart:html' show WebSocket, MessageEvent;
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
@@ -1020,7 +1021,7 @@ class ObservatoryLocation extends DebugLocation {
   }
 
   void _checkCreateSystemScript() {
-    if (existsSync(_path)) return;
+    if (fs.existsSync(_path)) return;
 
     _unableToResolve = true;
 
@@ -1163,7 +1164,7 @@ class _VmSourceCache {
 
   Map<String, String> _pathMappings = {};
 
-  _VmSourceCache() : cacheDir = join(tmpdir(), 'vm_cache');
+  _VmSourceCache() : cacheDir = fs.join(tmpdir(), 'vm_cache');
 
   _VmSourceCache.withDir(this.cacheDir);
 
@@ -1172,9 +1173,9 @@ class _VmSourceCache {
       List<String> safeNames = _createSafePathNames(originalPath);
       String filePath;
       if (safeNames.length == 2) {
-        filePath = join(cacheDir, safeNames[0], safeNames[1]);
+        filePath = fs.join(cacheDir, safeNames[0], safeNames[1]);
       } else {
-        filePath = join(cacheDir, safeNames[0]);
+        filePath = fs.join(cacheDir, safeNames[0]);
       }
       _createFile(filePath, source);
       _pathMappings[originalPath] = filePath;
@@ -1199,7 +1200,7 @@ class _VmSourceCache {
         Uri uri = Uri.parse(path);
         String temp = uri.path;
         if (temp.contains('/')) {
-          return [dirname(temp), basename(temp)];
+          return [fs.dirname(temp), basename(temp)];
         } else {
           return temp.contains('.') ? [temp] : [temp + '.dart'];
         }

--- a/lib/debug/utils.dart
+++ b/lib/debug/utils.dart
@@ -1,4 +1,6 @@
 
+import 'package:atom/node/fs.dart';
+
 import '../atom.dart';
 
 /// [line] and [column] are 1-based.
@@ -22,7 +24,7 @@ String getDisplayUri(String uri) {
   if (uri.startsWith('file:')) {
     String path = Uri.parse(uri).toFilePath();
     return atom.project.relativizePath(path)[1];
-  } else if (existsSync(uri)) {
+  } else if (fs.existsSync(uri)) {
     return atom.project.relativizePath(uri)[1];
   } else if (uri.startsWith('packages/')) {
     return 'package:${uri.substring(9)}';

--- a/lib/error_repository.dart
+++ b/lib/error_repository.dart
@@ -2,11 +2,11 @@ library atom.error_repository;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import 'analysis/analysis_server_lib.dart'
     show AnalysisErrors, AnalysisError, AnalysisFlushResults, Location;
-import 'atom.dart' show Directory, File, statSync;
 import 'utils.dart';
 
 final Logger _logger = new Logger('error_repository');
@@ -68,7 +68,7 @@ class ErrorRepository implements Disposable {
 
     // We use statSync() here and not file.isFile() as File.isFile() always
     // returns true.
-    if (file.existsSync() && statSync(path).isFile()) {
+    if (file.existsSync() && fs.statSync(path).isFile()) {
       var oldErrors = knownErrors[path];
       var newErrors = analysisErrors.errors;
 

--- a/lib/flutter/flutter_launch.dart
+++ b/lib/flutter/flutter_launch.dart
@@ -2,9 +2,9 @@ library atom.flutter.flutter_launch;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
-import '../atom.dart';
 import '../atom_utils.dart';
 import '../debug/debugger.dart';
 import '../debug/observatory_debugger.dart' show ObservatoryDebugger;
@@ -265,7 +265,7 @@ class FlutterUriTranslator implements UriTranslator {
     if (str.startsWith(_packagesPrefix)) {
       // Convert packages/ prefix to package: one.
       return _packagePrefix + str.substring(_packagesPrefix.length);
-    } else if (existsSync(str)) {
+    } else if (fs.existsSync(str)) {
       return new Uri.file(str).toString();
     } else {
       return str;

--- a/lib/flutter/flutter_sdk.dart
+++ b/lib/flutter/flutter_sdk.dart
@@ -2,6 +2,7 @@ library atom.flutter.flutter_sdk;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import '../atom.dart';
@@ -211,7 +212,7 @@ class FlutterSdk {
   bool get isValidSdk => new File.fromPath(flutterToolPath).existsSync();
 
   String get flutterToolPath {
-    return join(path, 'bin', isWindows ? 'flutter.bat' : 'flutter');
+    return fs.join(path, 'bin', isWindows ? 'flutter.bat' : 'flutter');
   }
 
   FlutterTool get flutterTool => new FlutterTool(this, flutterToolPath);
@@ -219,7 +220,7 @@ class FlutterSdk {
   /// Return the path to the Dart SDK contained within the Flutter SDK, if the
   /// Dart SDK is present.
   String get dartSdkPath {
-    String p = join(path, 'bin', 'cache', 'dart-sdk');
+    String p = fs.join(path, 'bin', 'cache', 'dart-sdk');
     if (new Directory.fromPath(p).existsSync()) return p;
     return null;
   }

--- a/lib/flutter/flutter_tools.dart
+++ b/lib/flutter/flutter_tools.dart
@@ -1,5 +1,6 @@
 library atom.flutter.create_project;
 
+import 'package:atom/node/fs.dart';
 import 'package:haikunator/haikunator.dart';
 
 import '../atom.dart';
@@ -39,8 +40,8 @@ class FlutterToolsManager implements Disposable {
     }
 
     String projectName = Haikunator.haikunate(delimiter: '_');
-    String parentPath = dirname(_flutterSdk.sdk.path);
-    String projectPath = join(parentPath, projectName);
+    String parentPath = fs.dirname(_flutterSdk.sdk.path);
+    String projectPath = fs.join(parentPath, projectName);
 
     String _response;
     FlutterTool flutter = _flutterSdk.sdk.flutterTool;
@@ -61,7 +62,7 @@ class FlutterToolsManager implements Disposable {
     }).then((_) {
       if (_response != null) {
         atom.project.addPath(_response);
-        String path = join(_response, 'lib', 'main.dart');
+        String path = fs.join(_response, 'lib', 'main.dart');
         atom.workspace.open(path).then((TextEditor editor) {
           // Focus the file in the files view 'tree-view:reveal-active-file'.
           atom.commands.dispatch(

--- a/lib/impl/changelog.dart
+++ b/lib/impl/changelog.dart
@@ -3,6 +3,7 @@ library atom.changelog;
 import 'dart:async';
 import 'dart:html' show HttpRequest;
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 //import 'package:pub_semver/pub_semver.dart';
 

--- a/lib/impl/pub.dart
+++ b/lib/impl/pub.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:convert' show JSON;
 import 'dart:html' show HttpRequest;
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 import 'package:pub_semver/pub_semver.dart';
 
@@ -32,10 +33,10 @@ class PubManager implements Disposable, ContextMenuContributor {
   PubManager() {
     // get, update, run
     _addSdkCmd('atom-text-editor', 'dartlang:pub-get', (event) {
-      new PubJob.get(dirname(event.editor.getPath())).schedule();
+      new PubJob.get(fs.dirname(event.editor.getPath())).schedule();
     });
     _addSdkCmd('atom-text-editor', 'dartlang:pub-upgrade', (event) {
-      new PubJob.upgrade(dirname(event.editor.getPath())).schedule();
+      new PubJob.upgrade(fs.dirname(event.editor.getPath())).schedule();
     });
     _addSdkCmd('atom-text-editor', 'dartlang:pub-run', (event) {
       _handleRun(editor: atom.workspace.getActiveTextEditor());
@@ -152,13 +153,13 @@ class PubManager implements Disposable, ContextMenuContributor {
 
     // Prefer checking for a .packages file.
     if (dotPackagesFile.existsSync()) {
-      var pubspecTime = statSync(pubspecYamlFile.path).mtime;
-      var packagesTime = statSync(dotPackagesFile.path).mtime;
+      var pubspecTime = fs.statSync(pubspecYamlFile.path).mtime;
+      var packagesTime = fs.statSync(dotPackagesFile.path).mtime;
       bool dirty = pubspecTime.compareTo(packagesTime) > 0;
       if (dirty) _showRunPubDialog(project);
     } else if (pubspecLockFile.existsSync()) {
-      var pubspecTime = statSync(pubspecYamlFile.path).mtime;
-      var lockTime = statSync(pubspecLockFile.path).mtime;
+      var pubspecTime = fs.statSync(pubspecYamlFile.path).mtime;
+      var lockTime = fs.statSync(pubspecLockFile.path).mtime;
       bool dirty = pubspecTime.compareTo(lockTime) > 0;
       if (dirty) _showRunPubDialog(project);
     } else {
@@ -322,7 +323,7 @@ class PubAppLocal extends PubApp {
 
   /// Returns whether this pub app is installed.
   bool isInstalledSync() {
-    File packagesFile = new File.fromPath(join(cwd, dotPackagesFileName));
+    File packagesFile = new File.fromPath(fs.join(cwd, dotPackagesFileName));
     if (!packagesFile.existsSync()) return false;
     String contents = packagesFile.readSync();
     return contents.split('\n').any((String line) => line.startsWith('${name}:'));
@@ -429,9 +430,9 @@ class PubRunJob extends Job {
 
 String _locatePubspecDir(String path) {
   if (path == null) return null;
-  if (path.endsWith(pubspecFileName)) return dirname(path);
+  if (path.endsWith(pubspecFileName)) return fs.dirname(path);
 
-  File f = new File.fromPath(join(path, pubspecFileName));
+  File f = new File.fromPath(fs.join(path, pubspecFileName));
   if (f.existsSync()) return path;
 
   DartProject project = projectManager.getProjectFor(path);
@@ -488,7 +489,7 @@ class PubContextCommand extends ContextMenuItem {
     if (project == null) return null;
 
     if (onlyPubspec) {
-      File file = new File.fromPath(join(project.path, pubspecFileName));
+      File file = new File.fromPath(fs.join(project.path, pubspecFileName));
       return file.existsSync();
     } else {
       return true;

--- a/lib/impl/rebuild.dart
+++ b/lib/impl/rebuild.dart
@@ -7,6 +7,8 @@ library atom.rebuild;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
+
 import '../atom.dart';
 import '../jobs.dart';
 import '../state.dart';

--- a/lib/impl/smoketest.dart
+++ b/lib/impl/smoketest.dart
@@ -7,6 +7,8 @@ library atom.smoketest;
 import 'dart:async';
 import 'dart:html' show DivElement;
 
+import 'package:atom/node/fs.dart';
+
 import '../atom.dart';
 import '../atom_utils.dart';
 import '../jobs.dart';

--- a/lib/launch/launch.dart
+++ b/lib/launch/launch.dart
@@ -4,11 +4,11 @@ library atom.launch;
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import '../analysis_server.dart';
 import '../atom.dart';
-import '../atom_utils.dart';
 import '../debug/debugger.dart';
 import '../projects.dart';
 import '../state.dart';
@@ -376,20 +376,20 @@ class _PathResolver implements _Resolver {
 
     String path;
 
-    if (url[0] == '/' || url[0] == separator || url[1] == ':') {
+    if (url[0] == '/' || url[0] == fs.separator || url[1] == ':') {
       path = url;
     } else if (cwd != null) {
-      path = join(cwd, url);
+      path = fs.join(cwd, url);
     }
 
     if (path == null) return null;
-    if (existsSync(path)) return new Future.value(path);
+    if (fs.existsSync(path)) return new Future.value(path);
 
     try {
       Uri uri = Uri.parse(url);
       if (uri.scheme == 'file') {
         path = uri.path;
-        if (existsSync(path)) return new Future.value(path);
+        if (fs.existsSync(path)) return new Future.value(path);
       }
     } catch (_) { }
 

--- a/lib/launch/launch_cli.dart
+++ b/lib/launch/launch_cli.dart
@@ -2,6 +2,7 @@ library atom.launch_cli;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import '../atom.dart';
@@ -37,14 +38,14 @@ class CliLaunchType extends LaunchType {
     } else {
       // Check that the file is not in lib/.
       String relativePath = relativize(project.path, path);
-      if (relativePath.startsWith('lib${separator}')) return false;
+      if (relativePath.startsWith('lib${fs.separator}')) return false;
 
       return analysisServer.isExecutable(path);
     }
   }
 
   List<String> getLaunchablesFor(DartProject project) {
-    final String libSuffix = 'lib${separator}';
+    final String libSuffix = 'lib${fs.separator}';
 
     return analysisServer.getExecutablesFor(project.path).where((String path) {
       // Check that the file is not in lib/.

--- a/lib/launch/launch_configs.dart
+++ b/lib/launch/launch_configs.dart
@@ -3,6 +3,7 @@ library atom.launch_configs;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 import 'package:yaml/yaml.dart';
 
@@ -148,7 +149,7 @@ class LaunchConfiguration {
   String get primaryResource {
     return shortResourceName == null
       ? null
-      : join(projectPath, shortResourceName);
+      : fs.join(projectPath, shortResourceName);
   }
 
   /// Return the type specific arguments for this launch configuration.
@@ -161,9 +162,9 @@ class LaunchConfiguration {
     if (typeArgs['cwd'] is String) {
       String str = typeArgs['cwd'].trim();
       if (str.isEmpty) return null;
-      if (str.startsWith(separator) || str.startsWith('/')) return str;
+      if (str.startsWith(fs.separator) || str.startsWith('/')) return str;
       if (isWindows && str.length >= 2 && str[1] == ':') return str;
-      return join(projectPath, str);
+      return fs.join(projectPath, str);
     } else {
       return null;
     }
@@ -226,10 +227,10 @@ class LaunchConfiguration {
 
   String _getRelativeConfigPath() {
     String path = _file.path;
-    String parent = dirname(projectPath);
+    String parent = fs.dirname(projectPath);
     if (path.startsWith(parent)) {
       path = path.substring(parent.length);
-      if (path.startsWith(separator)) path = path.substring(1);
+      if (path.startsWith(fs.separator)) path = path.substring(1);
       return path;
     } else {
       return path;
@@ -247,7 +248,7 @@ class LaunchConfiguration {
 }
 
 Directory _getLaunchDir(String projectPath) {
-  return new Directory.fromPath(join(projectPath, '.atom', 'launches'));
+  return new Directory.fromPath(fs.join(projectPath, '.atom', 'launches'));
 }
 
 class _ProjectConfigurations implements Disposable {

--- a/lib/launch/run.dart
+++ b/lib/launch/run.dart
@@ -2,10 +2,10 @@ library atom.run;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 
 import '../atom.dart';
-import '../atom_utils.dart';
 import '../projects.dart';
 import '../state.dart';
 import '../utils.dart';
@@ -169,7 +169,7 @@ class RunApplicationManager implements Disposable, ContextMenuContributor {
 
     if (relativePath.startsWith(projectPath)) {
       relativePath = relativePath.substring(projectPath.length);
-      if (relativePath.startsWith(separator)) relativePath = relativePath.substring(1);
+      if (relativePath.startsWith(fs.separator)) relativePath = relativePath.substring(1);
     }
 
     return launchConfigurationManager.createNewConfig(

--- a/lib/projects.dart
+++ b/lib/projects.dart
@@ -7,6 +7,7 @@ library atom.projects;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
@@ -316,7 +317,7 @@ class ProjectManager implements Disposable, ContextMenuContributor {
       path = response;
 
       // Verify the path.
-      if (!statSync(path).isDirectory()) {
+      if (!fs.statSync(path).isDirectory()) {
         atom.notifications.addWarning("'${path}' is not a directory.");
         return;
       }
@@ -328,7 +329,7 @@ class ProjectManager implements Disposable, ContextMenuContributor {
       }
 
       // Create the analysis options file and open it.
-      File file = new File.fromPath(join(path, analysisOptionsFileName));
+      File file = new File.fromPath(fs.join(path, analysisOptionsFileName));
       file.writeSync('''
 # ${analysisOptionsFileName}
 meta:
@@ -391,7 +392,7 @@ class DartProject {
   String get workspaceRelativeName {
     List<String> relPaths = atom.project.relativizePath(directory.path);
     if (relPaths[0] == null) return name;
-    return join(basename(relPaths[0]), relPaths[1]);
+    return fs.join(basename(relPaths[0]), relPaths[1]);
   }
 
   String getSelfRefName() {

--- a/lib/sdk.dart
+++ b/lib/sdk.dart
@@ -6,6 +6,7 @@ library atom.sdk;
 
 import 'dart:async';
 
+import 'package:atom/node/fs.dart';
 import 'package:logging/logging.dart';
 import 'package:pub_semver/pub_semver.dart';
 
@@ -198,7 +199,7 @@ class Sdk {
 
   String get path => directory.path;
 
-  String get binPath => join(path, 'bin');
+  String get binPath => fs.join(path, 'bin');
 
   Future<String> getVersion() {
     File file = directory.getFile('version');
@@ -211,15 +212,15 @@ class Sdk {
 
   File get dartVm {
     if (isWindows) {
-      return new File.fromPath(join(directory, 'bin', 'dart.exe'));
+      return new File.fromPath(fs.join(directory, 'bin', 'dart.exe'));
     } else {
-      return new File.fromPath(join(directory, 'bin', 'dart'));
+      return new File.fromPath(fs.join(directory, 'bin', 'dart'));
     }
   }
 
   String getSnapshotPath(String snapshotName) {
     File file = new File.fromPath(
-        join(directory, 'bin', 'snapshots', snapshotName));
+        fs.join(directory, 'bin', 'snapshots', snapshotName));
     return file.path;
   }
 
@@ -229,7 +230,7 @@ class Sdk {
     cwd, bool startProcess: true
   }) {
     if (cwd is Directory) cwd = cwd.path;
-    String command = join(directory, 'bin', isWindows ? '${binName}.bat' : binName);
+    String command = fs.join(directory, 'bin', isWindows ? '${binName}.bat' : binName);
 
     ProcessRunner runner =
         new ProcessRunner.underShell(command, args: args, cwd: cwd);
@@ -241,7 +242,7 @@ class Sdk {
   /// be either a [String] or a [Directory].
   Future<ProcessResult> execBinSimple(String binName, List<String> args, {cwd}) {
     if (cwd is Directory) cwd = cwd.path;
-    String command = join(directory, 'bin', isWindows ? '${binName}.bat' : binName);
+    String command = fs.join(directory, 'bin', isWindows ? '${binName}.bat' : binName);
     return new ProcessRunner.underShell(command, args: args, cwd: cwd).execSimple();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
   sdk: '>=1.9.0 <2.0.0'
 
 dependencies:
+  atom:
+    git: https://github.com/dart-atom/atom.dart.git
   haikunator: ^0.1.0
   logging: ^0.11.0
   markdown: ^0.9.0
@@ -16,8 +18,6 @@ dependencies:
   yaml: ^2.0.0
 
 dev_dependencies:
-  atom:
-    git: https://github.com/dart-atom/atom.dart.git
   grinder: ^0.8.0+1
   html: ^0.12.0
   test: ^0.12.0


### PR DESCRIPTION
This removes File, Directory, Entry, and the like from dartlang in favor of identical functionality in atom.dart.

@devoncarew 