### PR TITLE
feat(type-tooltip): Add a tooltip with type information on mouse hover.

### DIFF
--- a/lib/impl/tooltip.dart
+++ b/lib/impl/tooltip.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+import 'dart:html' as html;
+import 'dart:js';
+
+import 'package:atom_dartlang/analysis_server.dart';
+import 'package:atom_dartlang/elements.dart';
+import 'package:atom_dartlang/state.dart';
+import 'package:logging/logging.dart';
+
+import '../atom.dart';
+import '../projects.dart';
+import '../utils.dart';
+
+final Logger _logger = new Logger('atom.tooltip');
+
+/// Controls the hover tooltip with type information feature, capable of installing the feature
+/// into every active .dart editor.
+class TooltipController implements Disposable {
+  Disposables _disposables = new Disposables();
+
+  TooltipController() {
+    Timer.run(() {
+      _disposables.add(atom.workspace.observeTextEditors(_installInto));
+    });
+  }
+
+  void dispose() {
+    _disposables.dispose();
+  }
+
+  /// Installs the feature into [editor] if it responsible for a .dart file, noop if not.
+  void _installInto(TextEditor editor) {
+    if (!isDartFile(editor.getPath())) return;
+
+    new TooltipManager(editor);
+  }
+}
+
+/// Manages the display of tooltips for a single [TextEditor].
+class TooltipManager implements Disposable {
+  final TextEditor _editor;
+  final html.Element _root;
+
+  TooltipElement _tooltipElement;
+  StreamSubscriptions _subs = new StreamSubscriptions();
+
+  TooltipManager(TextEditor editor)
+      : this._editor = editor,
+        _root = editor.view['shadowRoot'] {
+    _subs.add(_editor.onDidDestroy.listen((_) => dispose()));
+
+    if (_root == null) {
+      _logger.warning("The editor's shadow root is null.");
+    } else {
+      _install();
+    }
+  }
+
+  void _install() {
+    _root.addEventListener('mousemove', (html.MouseEvent e) {
+      if (!_isTooltipEnabled) return;
+
+      int offset = _offsetFromMouseEvent(e);
+      new AnalysisRequestJob('hover-tooltip', () {
+        return analysisServer.getHover(_editor.getPath(), offset).then((HoverResult result) {
+          if (result == null) return;
+
+          result.hovers.forEach((HoverInformation h) {
+            // Get rid of previous tooltips.
+            _tooltipElement?.dispose();
+            _tooltipElement =
+                new TooltipElement(_editor, content: _tooltipContent(h), position: e.offset);
+          });
+        });
+      }).schedule();
+    });
+
+    _root.addEventListener('mouseout', (_) => _disposeTooltip());
+    _root.addEventListener('keydown', (_) => _disposeTooltip());
+  }
+
+  /// Returns true if the tooltip feature is enabled.
+  bool get _isTooltipEnabled => atom.config.getValue('$pluginId.hoverTooltip');
+
+  /// Returns the offset in the current buffer corresponding to the screen position of the
+  /// [MouseEvent].
+  int _offsetFromMouseEvent(html.MouseEvent e) {
+    JsObject component = _editor.view['component'];
+    Point bufferPt = component.callMethod('screenPositionForMouseEvent', [e]);
+    return _editor.getBuffer().characterIndexForPosition(bufferPt);
+  }
+
+  /// Returns the content to put into the tooltip based on [hover].
+  String _tooltipContent(HoverInformation hover) =>
+      hover.elementDescription ?? hover.staticType ?? hover.propagatedType;
+
+  void _disposeTooltip() {
+    _tooltipElement?.dispose();
+  }
+
+  @override
+  void dispose() {
+    _disposeTooltip();
+  }
+}
+
+/// Basic tooltip element with single [String] content capable of attaching itself to a [TextEditor]
+/// at a given position relative to its top,left corner.
+class TooltipElement extends CoreElement {
+  static const int _offset = 12;
+
+  final String content;
+
+  Disposable _cmdDispose;
+  StreamSubscription _sub;
+
+  TooltipElement(TextEditor editor, {this.content, html.Point position})
+      : super('div', classes: 'hover-tooltip') {
+    id = 'hover-tooltip';
+
+    _cmdDispose = atom.commands.add('atom-workspace', 'core:cancel', (_) => dispose());
+    _sub = editor.onDidDestroy.listen((_) => dispose());
+
+    // Set position at the mouseevent coordinates.
+    int x = position.x + _offset;
+    int y = position.y + _offset;
+    attributes['style'] = 'top: ${y}px; left: ${x}px;';
+
+    // Actually create the tooltip element.
+    add(div(c: 'hover-tooltip-title')).add(div(text: content, c: 'inline-block'));
+
+    // Attach the tooltip to the editor view.
+    html.DivElement parent = editor.view['parentElement'];
+    if (parent == null) return;
+    parent.append(this.element);
+  }
+
+  void dispose() {
+    _sub.cancel();
+    _cmdDispose.dispose();
+    super.dispose();
+  }
+}

--- a/lib/plugin.dart
+++ b/lib/plugin.dart
@@ -68,6 +68,7 @@ import 'usage.dart' show UsageManager;
 import 'utils.dart';
 import 'views.dart';
 import 'views.dart' show ViewGroupManager;
+import 'package:atom_dartlang/impl/tooltip.dart';
 
 export 'atom.dart' show registerPackage;
 
@@ -154,6 +155,7 @@ class AtomDartPackage extends AtomPackage {
     disposables.add(new NavigationHelper());
     disposables.add(new OrganizeFileManager());
     disposables.add(new OutlineController());
+    disposables.add(new TooltipController());
     disposables.add(pubManager);
     disposables.add(runAppManager);
     disposables.add(new RefactoringHelper());
@@ -388,6 +390,14 @@ class AtomDartPackage extends AtomPackage {
         'type': 'boolean',
         'default': false,
         'order': 11
+      },
+
+      // experimental features
+      'hoverTooltip': {
+        'title': '[Experimental] Enable type information tooltip.',
+        'type': 'boolean',
+        'default': false,
+        'order': 12
       }
     };
   }

--- a/lib/plugin.dart
+++ b/lib/plugin.dart
@@ -9,6 +9,7 @@ import 'dart:js';
 
 import 'package:atom/node/process.dart';
 import 'package:atom/node/shell.dart';
+import 'package:atom_dartlang/impl/tooltip.dart';
 import 'package:logging/logging.dart';
 
 import 'analysis/analysis_options.dart';
@@ -68,7 +69,6 @@ import 'usage.dart' show UsageManager;
 import 'utils.dart';
 import 'views.dart';
 import 'views.dart' show ViewGroupManager;
-import 'package:atom_dartlang/impl/tooltip.dart';
 
 export 'atom.dart' show registerPackage;
 

--- a/styles/tooltip.less
+++ b/styles/tooltip.less
@@ -1,0 +1,14 @@
+#hover-tooltip {
+  background-color: #226AEF;
+  border-radius: 2px;
+  bottom: inherit;
+  box-shadow: 0px 0px 8px #13213C;
+  color: #FFF;
+  font-size: 14px;
+  left: 0px;
+  padding: 5px 10px;
+  position: absolute;
+  right: inherit;
+  top: 0px;
+  z-index: 10000;
+}


### PR DESCRIPTION
The tooltip appears when mousing over something in an editor and contains the same information as the title bar of `F1 dartdoc` information. It is currently hidden behind an experimental flag `hoverTooltip` set to `false` by default.

The tooltip in action:
![tooltip_example](https://cloud.githubusercontent.com/assets/16721021/13410450/c9cf1704-df2f-11e5-89d3-a33adec34136.gif)

While roughly works, the functionality is here to be discussed and there is some work to be done on the content of the tooltip, the colors (hardcoded to blue and white right now), debouncing, and it currently shows even when the content is empty.

Linked to #7.