### PR TITLE
feat(comment-edit): Auto-close comment block when hitting enter after /*.

### DIFF
--- a/lib/atom.dart
+++ b/lib/atom.dart
@@ -726,6 +726,11 @@ class TextEditor extends ProxyHolder {
       invoke('setCursorBufferPosition', point);
   void selectRight(columnCount) => invoke('selectRight', columnCount);
 
+  void moveUp(int lineCount) => invoke('moveUp', lineCount);
+  void moveDown(int lineCount) => invoke('moveDown', lineCount);
+  void moveLeft(int rowCount) => invoke('moveLeft', rowCount);
+  void moveRight(int rowCount) => invoke('moveRight', rowCount);
+
   String lineTextForBufferRow(int bufferRow) =>
       invoke('lineTextForBufferRow', bufferRow);
 


### PR DESCRIPTION
Automatically close the comment block by inserting `*`, `*/` when pressing enter after opening a block comment `/*`.

The new behaviour looks like this:
![autoclose_comment](https://cloud.githubusercontent.com/assets/16721021/13445655/64bdcf5a-e005-11e5-80f2-90224a70d7e1.gif)

Also added `move_` methods to `TextEditor` façade and removed now obsolete tricks to close the comment by adding a `/` on the last line and hitting enter.

Closes #827