### PR TITLE
feat(comment-editing): Automatically wrap a comment that is longer than ...

### DIFF
--- a/lib/atom.dart
+++ b/lib/atom.dart
@@ -690,12 +690,7 @@ class TextEditor extends ProxyHolder {
 
   String selectAll() => invoke('selectAll');
 
-  // /// An ambiguous type:
-  // /// {
-  // ///   'scopes': ['source.dart']
-  // /// }
-  // ScopeDescriptor getRootScopeDescriptor() =>
-  //     new ScopeDescriptor(invoke('getRootScopeDescriptor'));
+  dynamic getRootScopeDescriptor() => invoke('getRootScopeDescriptor');
 
   /// Get the syntactic scopeDescriptor for the given position in buffer
   /// coordinates.
@@ -731,6 +726,13 @@ class TextEditor extends ProxyHolder {
   void moveDown(int lineCount) => invoke('moveDown', lineCount);
   void moveLeft(int rowCount) => invoke('moveLeft', rowCount);
   void moveRight(int rowCount) => invoke('moveRight', rowCount);
+  void moveToBeginningOfLine() => invoke('moveToBeginningOfLine');
+  void moveToBeginningOfScreenLine() => invoke('moveToBeginningOfScreenLine');
+  void moveToFirstCharacterOfLine() => invoke('moveToFirstCharacterOfLine');
+  void moveToEndOfLine() => invoke('moveToEndOfLine');
+  void moveToEndOfScreenLine() => invoke('moveToEndOfScreenLine');
+  void moveToBeginningOfWord() => invoke('moveToBeginningOfWord');
+  void moveToEndOfWord() => invoke('moveToEndOfWord');
 
   String lineTextForBufferRow(int bufferRow) =>
       invoke('lineTextForBufferRow', bufferRow);
@@ -862,9 +864,6 @@ class TextEditor extends ProxyHolder {
   // through JS interop.
   dynamic get view => atom.views.getView(obj);
 
-  String toString() => getTitle();
-
-  void moveToEndOfLine() => invoke('moveToEndOfLine');
   void selectToBeginningOfWord() => invoke('selectToBeginningOfWord');
 
   /// Get the position of the most recently added cursor in buffer coordinates.
@@ -899,6 +898,8 @@ class TextEditor extends ProxyHolder {
   Stream<Gutter> get onDidAddGutter => eventStream('onDidAddGutter').map((g) => new Gutter(g));
 
   Stream<Gutter> get onDidRemoveGutter => eventStream('onDidRemoveGutter').map((g) => new Gutter(g));
+
+  @override String toString() => getTitle();
 }
 
 class Gutter extends ProxyHolder {

--- a/lib/impl/editing.dart
+++ b/lib/impl/editing.dart
@@ -10,11 +10,6 @@ import '../atom.dart';
 
 final Logger _logger = new Logger('editing');
 
-// TODO: If we're in a line comment, and the line is longer than the max line
-// length, extend the comment.
-// var prefLineLength = atom.config.get('editor.preferredLineLength',
-//   scope: editor.getRootScopeDescriptor());
-
 // TODO: Tests for this.
 
 /// Handle special behavior for the enter key in Dart files. In particular, this
@@ -101,6 +96,22 @@ bool _handleEnterKey(TextEditor editor, int row, int col) {
       });
 
       return true;
+    } else if (atEol) {
+      var prefLineLength = atom.config
+          .getValue('editor.preferredLineLength', scope: editor.getRootScopeDescriptor());
+
+      if (col >= prefLineLength) {
+        int wrapAtCol = line.substring(0, prefLineLength + 1).lastIndexOf(' ');
+
+        editor.atomic(() {
+          editor.moveLeft(col - wrapAtCol);
+          editor.insertNewline();
+          editor.insertText('// ');
+          editor.moveToEndOfLine();
+        });
+
+        return true;
+      }
     }
 
     return false;

--- a/lib/impl/editing.dart
+++ b/lib/impl/editing.dart
@@ -97,11 +97,15 @@ bool _handleEnterKey(TextEditor editor, int row, int col) {
 
       return true;
     } else if (atEol) {
-      var prefLineLength = atom.config
-          .getValue('editor.preferredLineLength', scope: editor.getRootScopeDescriptor());
+      var prefLineLength = atom.config.getValue('editor.preferredLineLength',
+          scope: editor.getRootScopeDescriptor());
 
       if (col >= prefLineLength) {
         int wrapAtCol = line.substring(0, prefLineLength + 1).lastIndexOf(' ');
+
+        // Do not wrap if the comment consists only of a single word.
+        String left = line.substring(0, wrapAtCol).trimLeft().substring(2);
+        if (left.trim().isEmpty) return false;
 
         editor.atomic(() {
           editor.moveLeft(col - wrapAtCol);


### PR DESCRIPTION
...the configured preferred line length + added several `moveTo_` methods to `TextEditor`.

![comment_wrapping](https://cloud.githubusercontent.com/assets/16721021/13547561/0cb3341c-e2d0-11e5-96e5-6c98303e6f88.gif)

As a follow-up to this, after cleaning up the logic, I will add the same wrapping behaviour to the other kind of comments. 