### PR TITLE
integrate Dartino launching into dartlang framework - part 2

### DIFF
--- a/lib/dartino/dartino_util.dart
+++ b/lib/dartino/dartino_util.dart
@@ -80,7 +80,8 @@ class _Dartino {
     if (sdkPath.isNotEmpty) {
       var sdk = sdkFor(null);
       if (sdk != null && sdk.validate()) {
-        atom.notifications.addSuccess('Valid SDK detected', detail: sdkPath);
+        atom.notifications
+            .addSuccess('Valid ${sdk.name} detected', detail: sdkPath);
       }
     }
   }

--- a/lib/dartino/device/device.dart
+++ b/lib/dartino/device/device.dart
@@ -5,6 +5,7 @@ import 'package:atom_dartlang/atom.dart';
 import '../dartino_util.dart';
 import '../launch_dartino.dart';
 import '../sdk/dartino_sdk.dart';
+import '../sdk/sod_repo.dart';
 import 'stm32f746disco.dart';
 
 /// The connected device on which the application is executed.
@@ -41,7 +42,11 @@ abstract class Device {
     return device;
   }
 
-  /// Launch the specified application [binPath] on the device and return `true`.
+  /// Launch the specified application on the device and return `true`.
   /// If there is a problem, notify the user and return `false`.
   Future<bool> launchDartino(DartinoSdk sdk, DartinoLaunch launch);
+
+  /// Launch the specified application on the device and return `true`.
+  /// If there is a problem, notify the user and return `false`.
+  Future<bool> launchSOD(SodRepo sdk, DartinoLaunch launch);
 }

--- a/lib/dartino/sdk/dartino_sdk.dart
+++ b/lib/dartino/sdk/dartino_sdk.dart
@@ -59,6 +59,8 @@ class DartinoSdk extends Sdk {
   /// Return the path to the dartino command line binary
   String get dartinoBinary => resolvePath('bin/dartino');
 
+  String get name => 'Dartino SDK';
+
   /// Compile the application and return a path to the compiled binary.
   /// If there is a problem, notify the user and return `null`.
   Future<String> compile(DartinoLaunch launch) async {

--- a/lib/dartino/sdk/sdk.dart
+++ b/lib/dartino/sdk/sdk.dart
@@ -15,6 +15,8 @@ abstract class Sdk {
 
   Sdk(this.sdkRoot);
 
+  String get name;
+
   /// Return `true` if the specified file exists in the SDK
   bool existsSync(String relativePosixPath) {
     var path = resolvePath(relativePosixPath);

--- a/lib/dartino/sdk/sod_repo.dart
+++ b/lib/dartino/sdk/sod_repo.dart
@@ -4,6 +4,7 @@ import 'package:atom/node/fs.dart';
 
 import '../../atom.dart';
 import '../dartino_util.dart';
+import '../device/device.dart';
 import '../launch_dartino.dart';
 import 'sdk.dart';
 
@@ -26,14 +27,44 @@ class SodRepo extends Sdk {
 
   SodRepo(String sdkRoot) : super(sdkRoot);
 
+  String get name => 'SOD repository';
+
+  String get sodUtil => resolvePath('dart/bin/sod.dart');
+
+  /// Compile the application and return the path of the binary to deploy.
+  /// If there is a problem, notify the user and return `null`.
+  Future<String> compile(DartinoLaunch launch) async {
+    String srcPath = launch.primaryResource;
+    String dstPath = srcPath.substring(0, srcPath.length - 5) + '.snap';
+
+    int exitCode = await launch.run('make',
+        args: [dstPath],
+        cwd: sdkRoot,
+        isLast: false,
+        message: 'Building $srcPath ...');
+    if (exitCode != 0) {
+      atom.notifications.addError('Failed to compile application',
+          detail: 'Failed to compile.\n'
+              '$srcPath\n'
+              'See console for more.');
+      return null;
+    }
+    return dstPath;
+  }
+
   @override
   Future launch(DartinoLaunch launch) async {
-    atom.notifications.addError('Not implemented yet');
+    Device device = await Device.forLaunch(launch);
+    if (device == null) return;
+    device.launchSOD(this, launch);
   }
 
   @override
   String packageRoot(projDir) {
-    return projDir != null ? fs.join(projDir, '.packages') : null;
+    if (projDir == null) return null;
+    String localSpecFile = fs.join(projDir, '.packages');
+    if (fs.existsSync(localSpecFile)) return localSpecFile;
+    return resolvePath('third_party/dartino//internal/dartino-sdk.packages');
   }
 
   @override


### PR DESCRIPTION
Following https://github.com/dart-atom/dartlang/pull/839, this integrates launching [SOD](https://github.com/domokit/sod) applications on the STM32 discovery board.

@devoncarew 