### PR TITLE
hide EventListener

### DIFF
--- a/lib/analysis/declaration_nav.dart
+++ b/lib/analysis/declaration_nav.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 import 'dart:js';
 
 import 'package:atom/node/process.dart';
-import 'package:atom/utils/disposable.dart';
+import 'package:atom/utils/disposable.dart' hide EventListener;
 import 'package:logging/logging.dart';
 
 import '../atom.dart';


### PR DESCRIPTION
I'm removing `dartlang/lib/js.dart` in favor of `atom.dart/lib/src/js.dart` and in the process moving EventListener into `atom.dart/lib/utils/disposables.dart`. This precursor CL prevents dartlang from trying to import EventListener from both old and new locations. This `hide EventListener` will be removed as part of removing `js.dart` from dartlang.
@devoncarew 