### PR TITLE
Support custom build rules in BUILD files

### DIFF
--- a/lib/projects.dart
+++ b/lib/projects.dart
@@ -509,13 +509,11 @@ class ProjectScanJob extends Job {
 }
 
 bool _isDartBuildFile(File file) {
-  const String marker1 = '/dart/build_defs';
-  const String marker2 = 'dart_library(';
-  const String marker3 = 'dart_analyzed_library';
-
+  const String marker = 'dart';
+  
   try {
     String contents = file.readSync();
-    return contents.contains(marker1) || contents.contains(marker2) || contents.contains(marker3);
+    return contents.contains(marker);
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
There are lots of cases where the markers are not finding anything because we only use wrapper rules. Just search for dart in the BUILD file.