### PR TITLE
Fix grammar rule for triple slash doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # dartlang plugin changelog
 
+## unreleased
+- fixed an issue with doc comment grammar.
+
 ## 0.6.6
 - added an option to change the break on exceptions mode in the debugger
   (break on all exceptions, break on uncaught exceptions, or don't break on exceptions)

--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -116,7 +116,7 @@
             'name': 'variable.other.source.dart'
       }
       {
-        'match': '(///) (.*?)$'
+        'match': '(///)( ?)(.*?)$'
         'captures':
           '1':
             'name': 'comment.block.triple-slash.dart'


### PR DESCRIPTION
Allows for doc comments to not have any content. Useful when a doc comment has a new line in order to make a new paragraph.

Came across this when setting custom CSS for doc comments.