### PR TITLE
display Flutter Material Design icons in dartdoc tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fixed an NPE in the debugger's stack frame view
 - updated to a new Atom API to open editors in a 'preview' mode, so we don't end
   up with a proliferation of open editors
+- display Flutter Material Design icons in dartdoc tooltips
 
 ## 0.6.6
 - added an option to change the break on exceptions mode in the debugger

--- a/lib/analysis/dartdoc.dart
+++ b/lib/analysis/dartdoc.dart
@@ -100,9 +100,14 @@ class DartdocHelper implements Disposable {
 
     if (hover.dartdoc != null) {
       if (buf.isNotEmpty) buf.write('<br>');
-      String html = markdown.markdownToHtml(
-          hover.dartdoc, linkResolver: _resolve);
-      buf.write('\n${html}\n');
+
+      if (hover.dartdoc.contains(' class="material-icons')) {
+        // <p><i class="material-icons md-48">menu</i> &#x2014; material...</p>
+        buf.write('\n${hover.dartdoc}\n');
+      } else {
+        String html = markdown.markdownToHtml(hover.dartdoc, linkResolver: _resolve);
+        buf.write('\n${html}\n');
+      }
     }
 
     return buf.toString();

--- a/styles/dartdoc.less
+++ b/styles/dartdoc.less
@@ -1,6 +1,13 @@
 @import "ui-variables";
 @import "syntax-variables";
 
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Material Icons'), local('MaterialIcons-Regular'), url('https://fonts.gstatic.com/s/materialicons/v13/2fcrYFNaTjcS6g4U3t-Y5UEw0lE80llgEseQY3FEmqw.woff2') format('woff2');
+}
+
 #dartdoc-tooltip {
   position: absolute;
   top: 8px;
@@ -14,6 +21,23 @@
   z-index: 100;
   font-size: 110%;
   border: none;
+
+  .material-icons {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    line-height: 1;
+    vertical-align: bottom;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-feature-settings: 'liga';
+    -webkit-font-smoothing: antialiased;
+  }
 
   .dartdoc-title {
     color: @text-color-highlight;


### PR DESCRIPTION
- display Flutter Material Design icons in dartdoc tooltips
- https://github.com/flutter/flutter/issues/2052

<img width="462" alt="screen shot 2016-03-18 at 4 12 47 pm" src="https://cloud.githubusercontent.com/assets/1269969/13894589/de5429b2-ed26-11e5-963f-a686b5c60c54.png">

@danrubel 