### PR TITLE
move show SDK docs into dartlang

### DIFF
--- a/lib/dartino/dartino_util.dart
+++ b/lib/dartino/dartino_util.dart
@@ -97,6 +97,11 @@ class _Dartino {
     DartinoSdk.promptInstall();
   }
 
+  /// Show docs for the installed SDK.
+  void showSdkDocs(AtomEvent _) {
+    sdkFor(null)?.showDocs();
+  }
+
   /// Validate the installed SDK if there is one.
   void validateSdk([AtomEvent _]) {
     if (sdkPath.isNotEmpty) {

--- a/lib/dartino/sdk/dartino_sdk.dart
+++ b/lib/dartino/sdk/dartino_sdk.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:atom/node/fs.dart';
 import 'package:atom/node/notification.dart';
 import 'package:atom/node/process.dart';
+import 'package:atom/node/shell.dart';
 import 'package:atom_dartlang/jobs.dart';
 import 'package:logging/logging.dart';
 
@@ -113,6 +114,12 @@ class DartinoSdk extends Sdk {
 
   @override
   bool validate({bool quiet: false}) => true;
+
+  @override
+  void showDocs() {
+    var uri = new Uri.file(fs.join(sdkRoot, 'docs', 'index.html'));
+    shell.openExternal(uri.toString());
+  }
 }
 
 /// Start downloading the latest Dartino SDK and return a [Future]

--- a/lib/dartino/sdk/sdk.dart
+++ b/lib/dartino/sdk/sdk.dart
@@ -83,4 +83,7 @@ abstract class Sdk {
     }
     return path;
   }
+
+  /// Show documentation for the installed SDK.
+  void showDocs();
 }

--- a/lib/dartino/sdk/sod_repo.dart
+++ b/lib/dartino/sdk/sod_repo.dart
@@ -102,4 +102,9 @@ class SodRepo extends Sdk {
     }
     return true;
   }
+
+  @override
+  void showDocs() {
+    atom.notifications.addInfo('no docs yet');
+  }
 }

--- a/lib/plugin.dart
+++ b/lib/plugin.dart
@@ -199,6 +199,7 @@ class AtomDartPackage extends AtomPackage {
     _addCmd('atom-workspace', 'dartino:create-new-proj', dartino.createNewProject);
     _addCmd('atom-workspace', 'dartino:create-new-project', dartino.createNewProject);
     _addCmd('atom-workspace', 'dartino:install-sdk', dartino.promptInstallSdk);
+    _addCmd('atom-workspace', 'dartino:sdk-docs', dartino.showSdkDocs);
     _addCmd('atom-workspace', 'dartino:validate-sdk', dartino.validateSdk);
 
     // Text editor commands.


### PR DESCRIPTION
move show SDK docs into dartlang so that duplicate code can be removed from the dartino plugin.
@devoncarew 