### PR TITLE
improve our support for BUILD files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 - several improvements to the Find Type dialog
+- improve the Dart detection logic in our BUILD file support
 
 ## 0.6.8
 - strip html markup from the code completion results

--- a/lib/projects.dart
+++ b/lib/projects.dart
@@ -49,9 +49,9 @@ class ProjectManager implements Disposable, ContextMenuContributor {
     if (dir.getFile(analysisOptionsFileName).existsSync()) return true;
 
     // Look for a `BUILD` file with some Dart build rules.
-    File buildFile = dir.getFile(_bazelBuildFileName);
-    if (buildFile.existsSync()) {
-      if (_isDartBuildFile(buildFile)) return true;
+    String buildFilePath = fs.join(dir.path, _bazelBuildFileName);
+    if (fs.existsSync(buildFilePath)) {
+      if (isDartBuildFile(buildFilePath)) return true;
     }
 
     // Look for dartino.yaml file... there is no .packages or pubspec
@@ -508,14 +508,13 @@ class ProjectScanJob extends Job {
   }
 }
 
-bool _isDartBuildFile(File file) {
-  const String marker1 = '/dart/build_defs';
-  const String marker2 = 'dart_library(';
-  const String marker3 = 'dart_analyzed_library';
+final RegExp _bazelDartRegex = new RegExp(r'[\W_]dart[\W_]');
+final RegExp _bazelFlutterRegex = new RegExp(r'[\W_]flutter[\W_]');
 
+bool isDartBuildFile(String path) {
   try {
-    String contents = file.readSync();
-    return contents.contains(marker1) || contents.contains(marker2) || contents.contains(marker3);
+    String contents = fs.readFileSync(path);
+    return _bazelDartRegex.hasMatch(contents) || _bazelFlutterRegex.hasMatch(contents);
   } catch (_) {
     return false;
   }

--- a/spec/all-spec.dart
+++ b/spec/all-spec.dart
@@ -2,13 +2,13 @@
 //import '_spec/sample-spec.dart' as sample_spec;
 
 import 'flutter/launch_flutter_test.dart' as launch_flutter_test;
+import 'projects_test.dart' as projects_test;
 import 'sdk_test.dart' as sdk_test;
-
-// TODO: Move tests over from smoketest.dart.
 
 main() {
   //animals_test.register();
   //sample_spec.main();
   launch_flutter_test.register();
+  projects_test.register();
   sdk_test.register();
 }

--- a/spec/projects_test.dart
+++ b/spec/projects_test.dart
@@ -1,0 +1,35 @@
+import 'package:atom_dartlang/projects.dart';
+import 'package:atom/node/fs.dart';
+
+import '_spec/test.dart';
+
+void register() => registerSuite(new ProjectsTest());
+
+class ProjectsTest extends TestSuite {
+  Map<String, Test> getTests() => {
+    // 'isDartBuildFile_findsProject': isDartBuildFile_findsProject,
+    'isDartBuildFile_noFalsePositive': isDartBuildFile_noFalsePositives
+  };
+
+  isDartBuildFile_findsProject() {
+    String path = _createTempFile('BUILD', '\n/dart/build_defs\n');
+    expect(isDartBuildFile(path), true);
+
+    path = _createTempFile('BUILD', '\ndart_library(\n');
+    expect(isDartBuildFile(path), true);
+
+    path = _createTempFile('BUILD', '\ndart_analyzed_library\n');
+    expect(isDartBuildFile(path), true);
+  }
+
+  isDartBuildFile_noFalsePositives() {
+    String path = _createTempFile('BUILD', '\ndarty\n');
+    expect(isDartBuildFile(path), false);
+  }
+}
+
+String _createTempFile(String name, String contents) {
+  String path = fs.join(fs.tmpdir, name);
+  fs.writeFileSync(path, contents);
+  return path;
+}

--- a/spec/sdk_test.dart
+++ b/spec/sdk_test.dart
@@ -5,44 +5,27 @@ import '_spec/test.dart';
 void register() => registerSuite(new SdkTest());
 
 class SdkTest extends TestSuite {
-  SdkManager _manager;
-
   Map<String, Test> getTests() => {
-    '_autoConfigure': _autoConfigure,
-    '_sdkDiscovery': _sdkDiscovery,
-    // '_hasSdk': _hasSdk,
-    // '_getVersion': _getVersion
+    '_autoConfigure': autoConfigure,
+    '_sdkDiscovery': sdkDiscovery
   };
+
+  SdkManager _manager;
 
   setUp() => _manager = new SdkManager();
   tearDown() => _manager?.dispose();
 
-  _autoConfigure() {
+  autoConfigure() {
     return _manager.tryToAutoConfigure().then((result) {
       print(result);
       expect(result, true);
     });
   }
 
-  _sdkDiscovery() {
+  sdkDiscovery() {
     return new SdkDiscovery().discoverSdk().then((String foundSdk) {
       print('discoverSdk: ${foundSdk}');
       expect(foundSdk is String, true);
     });
   }
-
-  // _hasSdk() {
-  //   return _manager.tryToAutoConfigure().then((_) {
-  //     expect(_manager.sdk != null, true);
-  //     expect(_manager.hasSdk, true);
-  //   });
-  // }
-  //
-  // _getVersion() {
-  //   return _manager.tryToAutoConfigure().then((_) {
-  //     return _manager.sdk.getVersion();
-  //   }).then((ver) {
-  //     expect(ver is String, true);
-  //   });
-  // }
 }


### PR DESCRIPTION
Widen what we look for in BUILD files; any `dart` reference (surrounded by non-word chars). 

@danrubel 