### PR TITLE
refactor dartlang package functionality to mirror atom.dart

### DIFF
--- a/lib/atom_package_deps.dart
+++ b/lib/atom_package_deps.dart
@@ -7,13 +7,12 @@ import 'package:atom/node/process.dart';
 import 'package:logging/logging.dart';
 
 import 'atom.dart';
-import 'atom_utils.dart';
 import 'jobs.dart';
 
 final Logger _logger = new Logger('atom.atom_package_deps');
 
 Future install() {
-  return loadPackageJson().then((Map info) {
+  return atomPackage.loadPackageJson().then((Map info) {
     List<String> installedPackages = atom.packages.getAvailablePackageNames();
     List<String> requiredPackages = info['required-packages'];
 

--- a/lib/atom_utils.dart
+++ b/lib/atom_utils.dart
@@ -5,7 +5,6 @@
 library atom.atom_utils;
 
 import 'dart:async';
-import 'dart:convert' show JSON;
 import 'dart:html' show DivElement, Element, HttpRequest, Node, NodeValidator,
     NodeTreeSanitizer, window;
 
@@ -25,7 +24,7 @@ Future<String> getSystemDescription({bool sdkPath: false}) {
   String sdkVer;
   String os = isMac ? 'macos' : process.platform;
 
-  return getPackageVersion().then((ver) {
+  return atomPackage.getPackageVersion().then((ver) {
     pluginVer = ver;
     return sdkManager.hasSdk ? sdkManager.sdk.getVersion() : null;
   }).then((ver) {
@@ -53,14 +52,4 @@ class PermissiveNodeValidator implements NodeValidator {
   bool allowsAttribute(Element element, String attributeName, String value) {
     return true;
   }
-}
-
-Future<Map> loadPackageJson() {
-  return HttpRequest.getString('atom://dartlang/package.json').then((str) {
-    return JSON.decode(str);
-  });
-}
-
-Future<String> getPackageVersion() {
-  return loadPackageJson().then((map) => map['version']);
 }

--- a/lib/impl/changelog.dart
+++ b/lib/impl/changelog.dart
@@ -9,14 +9,13 @@ import 'package:atom/utils/disposable.dart';
 import 'package:logging/logging.dart';
 
 import '../atom.dart';
-import '../atom_utils.dart';
 import '../state.dart';
 //import 'package:pub_semver/pub_semver.dart';
 
 
 final Logger _logger = new Logger('changelog');
 
-Future checkChangelog() => getPackageVersion().then(_checkChangelog);
+Future checkChangelog() => atomPackage.getPackageVersion().then(_checkChangelog);
 
 class ChangelogManager implements Disposable {
   Disposables disposables = new Disposables();

--- a/lib/impl/status.dart
+++ b/lib/impl/status.dart
@@ -114,7 +114,7 @@ class StatusView extends View {
     CoreElement section = container.add(div(c: 'view-section'));
     StatusHeader header = new StatusHeader(section);
     header.title.text = '${pluginId} plugin';
-    getPackageVersion().then((str) {
+    atomPackage.getPackageVersion().then((str) {
       header.subtitle.text = str;
     });
 
@@ -453,7 +453,7 @@ class StatusHeader {
 
 /// 'Atom 1.0.11, dartlang 0.4.3'
 Future<String> _getPlatformVersions() {
-  return getPackageVersion().then((pluginVer) {
+  return atomPackage.getPackageVersion().then((pluginVer) {
     String atomVer = atom.getVersion();
     return 'Atom ${atomVer}, ${pluginId} ${pluginVer}';
   });

--- a/lib/plugin.dart
+++ b/lib/plugin.dart
@@ -84,7 +84,7 @@ class AtomDartPackage extends AtomPackage {
   ConsoleController consoleController;
   DartLinterConsumer _consumer;
 
-  AtomDartPackage() {
+  AtomDartPackage() : super(pluginId) {
     // Register a method to consume the `status-bar` service API.
     registerServiceConsumer('consumeStatusBar', (JsObject obj) {
       StatusBar statusBar = new StatusBar(obj);
@@ -115,7 +115,7 @@ class AtomDartPackage extends AtomPackage {
     moduleExports['provideAutocomplete'] = () => dartCompleterProvider.toProxy();
   }
 
-  void packageActivated([dynamic pluginState]) {
+  void activate([dynamic pluginState]) {
     _setupLogging();
 
     _logger.info("activated");
@@ -276,7 +276,7 @@ class AtomDartPackage extends AtomPackage {
 
   dynamic serialize() => state.saveState();
 
-  void packageDeactivated() {
+  void deactivate() {
     _logger.info('deactivated');
 
     disposables.dispose();

--- a/lib/usage.dart
+++ b/lib/usage.dart
@@ -7,7 +7,6 @@ import 'package:logging/logging.dart';
 import 'package:usage/usage_html.dart';
 
 import 'atom.dart';
-import 'atom_utils.dart';
 import 'projects.dart';
 import 'state.dart';
 
@@ -25,7 +24,7 @@ class UsageManager implements Disposable {
   }
 
   Future _init() {
-    return getPackageVersion().then((String version) {
+    return atomPackage.getPackageVersion().then((String version) {
       atom.config.observe('${pluginId}.sendUsage', null, (value) {
         // Disable Google Analytics if the UA is the placeholder one.
         if (_UA.startsWith('UA-0000')) value = false;


### PR DESCRIPTION
This is the second step towards having flutter, dartino, and dartlang using the same package infrastructure.
@devoncarew 