### PR TITLE
Increase the recursion depth searching for projects

### DIFF
--- a/lib/projects.dart
+++ b/lib/projects.dart
@@ -38,7 +38,7 @@ String getWorkspaceRelativeDescription(String path) {
 /// A class to locate Dart projects in Atom and listen for new or removed Dart
 /// projects.
 class ProjectManager implements Disposable, ContextMenuContributor {
-  static const int _recurseDepth = 3;
+  static const int _recurseDepth = 4;
 
   /// Return whether the given directory is a Dart project.
   static bool isDartProject(Directory dir) {


### PR DESCRIPTION
We need this for our project. I kept missing things in a sub-sub-sub-sub folder when I was doing refactorings because there were dart projects that weren't getting analyzed.

Actually I wonder how expensive it would be just to search all the way down. For the most part it's just reading directories. Is the concern mostly about a hypothetical giant mapped network drive containing billions of lines of source code? Could we just special-case that one?