### PR TITLE
Add an option to exclude particular directories. By default exclude .git

### DIFF
--- a/lib/plugin.dart
+++ b/lib/plugin.dart
@@ -391,6 +391,14 @@ class AtomDartPackage extends AtomPackage {
         'type': 'boolean',
         'default': false,
         'order': 13
+      },
+
+      'excludeDirectories': {
+        'title': '[Experimental] Exclude directories from indexing',
+        'description': 'A comma separated list of directory names to avoid '
+        'indexing',
+        'type': 'string',
+        'default': '.git'
       }
     };
   }

--- a/lib/projects.dart
+++ b/lib/projects.dart
@@ -275,7 +275,21 @@ class ProjectManager implements Disposable, ContextMenuContributor {
   //   }
   // }
 
+  final Set<String> _excludeDirectories = atom.config
+      .getValue('${pluginId}.excludeDirectories')
+      .toString()
+      .split(',')
+      .map((String dir) => dir.trim())
+      .toSet();
+
+  bool _excludeDirectory(Directory dir) =>
+      _excludeDirectories.contains(dir.getBaseName());
+
   List<Directory> _findDartProjects(Directory dir, int recurse) {
+    if (_excludeDirectory(dir)) {
+      return [];
+    }
+
     if (isDartProject(dir)) {
       return [dir];
     }


### PR DESCRIPTION
In our project we have a third_party/ directory that contains a lot of code that we don't maintain. Our build system also puts a lot of stuff in a out/ directory - some of which look like dart packages but aren't well formed. We don't want to treat things that look like dart projects in there as dart projects in the editor.

This may actually belong in a directory-specific dart-atom configuration, but I'm not sure what the best way to add that is.