### PR TITLE
expose the performance overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # dartlang plugin changelog
 
+## unreleased
+- exposed the performance overlay debug option for Flutter apps
+
 ## 0.6.12
 - adjusted the order of code completions
 - exposed the repaint rainbow debug option for Flutter apps

--- a/lib/flutter/flutter_ext.dart
+++ b/lib/flutter/flutter_ext.dart
@@ -53,11 +53,11 @@ class FlutterExt {
     );
   }
 
-  Future fpsOverlay(bool showOverlay) {
+  Future performanceOverlay(bool enabled) {
     return service.callServiceExtension(
-      '$_flutterPrefix.fpsOverlay',
+      '$_flutterPrefix.showPerformanceOverlay',
       isolateId: isolateId,
-      args: { 'showOverlay': showOverlay }
+      args: { 'enabled': enabled }
     );
   }
 

--- a/lib/flutter/flutter_ui.dart
+++ b/lib/flutter/flutter_ui.dart
@@ -3,13 +3,16 @@ import '../debug/observatory_debugger.dart';
 import '../elements.dart';
 import '../flutter/flutter_ext.dart';
 
+// TODO(devoncarew): We need to re-do the UI for the Flutter section to better
+// fit more elements (like a FPS label and the current route text).
+
 class FlutterSection {
   final DebugConnection connection;
 
   bool isDebugDrawing = false;
   bool isRepaintRainbow = false;
   bool isSlowAnimations = false;
-  bool isFPSOverlay = false;
+  bool isPerformanceOverlay = false;
 
   FlutterSection(this.connection, CoreElement element) {
     element.add([
@@ -37,14 +40,14 @@ class FlutterSection {
             ..setAttribute('type', 'checkbox')
             ..click(_toggleSlowAnimations),
           span(text: 'Slow animations', c: 'text-subtle')
+        ]),
+        new CoreElement('label')..add([
+          new CoreElement('input')
+            ..setAttribute('type', 'checkbox')
+            ..click(_togglePerformanceOverlay),
+          span(text: 'Performance overlay', c: 'text-subtle')
         ])
       ])
-      // new CoreElement('label')..add([
-      //   new CoreElement('input')
-      //     ..setAttribute('type', 'checkbox')
-      //     ..click(_toggleFPSOverlay),
-      //   span(text: 'FPS overlay', c: 'text-subtle')
-      // ])
     ]);
 
     element.hidden(true);
@@ -77,8 +80,8 @@ class FlutterSection {
     flutterExtension.timeDilation(isSlowAnimations ? 5.0 : 1.0);
   }
 
-  // void _toggleFPSOverlay() {
-  //   isFPSOverlay = !isFPSOverlay;
-  //   flutterExtension.fpsOverlay(isFPSOverlay);
-  // }
+  void _togglePerformanceOverlay() {
+    isPerformanceOverlay = !isPerformanceOverlay;
+    flutterExtension.performanceOverlay(isPerformanceOverlay);
+  }
 }


### PR DESCRIPTION
- expose the flutter performance overlay option (fix https://github.com/flutter/atom-flutter/issues/65)

<img width="478" alt="screen shot 2016-04-21 at 3 48 11 pm" src="https://cloud.githubusercontent.com/assets/1269969/14726639/91f958ae-07d8-11e6-9908-355d10109349.png">

@danrubel, @eseidelGoogle