### PR TITLE
save dirty editors before running pub get/upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 - exposed the performance overlay debug option for Flutter apps
+- re-enable format on save
+- save all files before running `pub get` or `pub upgrade`
 
 ## 0.6.12
 - adjusted the order of code completions

--- a/lib/flutter/flutter_tools.dart
+++ b/lib/flutter/flutter_tools.dart
@@ -92,6 +92,8 @@ class FlutterToolsManager implements Disposable {
       return;
     }
 
+    atom.workspace.saveAll();
+
     FlutterTool flutter = _flutterSdk.sdk.flutterTool;
     flutter.runInJob(['upgrade'],
       title: 'Running Flutter upgrade…',

--- a/lib/impl/pub.dart
+++ b/lib/impl/pub.dart
@@ -34,9 +34,11 @@ class PubManager implements Disposable, ContextMenuContributor {
   PubManager() {
     // get, update, run
     _addSdkCmd('atom-text-editor', 'dartlang:pub-get', (event) {
+      atom.workspace.saveAll();
       new PubJob.get(fs.dirname(event.editor.getPath())).schedule();
     });
     _addSdkCmd('atom-text-editor', 'dartlang:pub-upgrade', (event) {
+      atom.workspace.saveAll();
       new PubJob.upgrade(fs.dirname(event.editor.getPath())).schedule();
     });
     _addSdkCmd('atom-text-editor', 'dartlang:pub-run', (event) {
@@ -52,9 +54,11 @@ class PubManager implements Disposable, ContextMenuContributor {
     });
 
     _addSdkCmd('.tree-view', 'dartlang:pub-get', (AtomEvent event) {
+      atom.workspace.saveAll();
       new PubJob.get(event.targetFilePath).schedule();
     });
     _addSdkCmd('.tree-view', 'dartlang:pub-upgrade', (AtomEvent event) {
+      atom.workspace.saveAll();
       new PubJob.upgrade(event.targetFilePath).schedule();
     });
     _addSdkCmd('.tree-view', 'dartlang:pub-run', (AtomEvent event) {


### PR DESCRIPTION
- save dirty editors before running pub get/upgrade (fix https://github.com/flutter/flutter/issues/2300)

@danrubel 