### PR TITLE
fix an npe in the debugger

### DIFF
--- a/lib/debug/debugger.dart
+++ b/lib/debug/debugger.dart
@@ -187,7 +187,7 @@ class UriResolver implements Disposable {
 
       List<String> uris = [result.uri];
 
-      if (result.uri.startsWith(_selfRefPrefix)) {
+      if (_selfRefPrefix != null && result.uri.startsWith(_selfRefPrefix)) {
         String filePath = new Uri.file(root, windows: isWindows).toString();
         filePath += '/lib/${result.uri.substring(_selfRefPrefix.length)}';
         uris.insert(0, filePath);


### PR DESCRIPTION
Fix an NPE in the debugger when no self ref package is found (fix https://github.com/dart-atom/dartlang/issues/969).

@danrubel 