### PR TITLE
drop frame numbers from the debugger ui

### DIFF
--- a/lib/debug/debugger_ui.dart
+++ b/lib/debug/debugger_ui.dart
@@ -492,8 +492,7 @@ class ExecutionTab extends MTab {
           text: locationText,
           c: 'debugger-secondary-info right-aligned overflow-hidden-ellipsis'
         )..flex()
-      ])..flex(),
-      span(text: '#${frame.frameIndex}', c: 'debugger-secondary-info')
+      ])..flex()
     ])..layoutHorizontal();
   }
 

--- a/lib/debug/model.dart
+++ b/lib/debug/model.dart
@@ -68,8 +68,6 @@ abstract class DebugFrame {
 
   String get title;
 
-  int get frameIndex;
-
   bool get isSystem;
 
   List<DebugVariable> get locals;

--- a/lib/debug/observatory_debugger.dart
+++ b/lib/debug/observatory_debugger.dart
@@ -568,10 +568,9 @@ class ObservatoryIsolate extends DebugIsolate {
     return service.getStack(id).then((Stack stack) {
       List<ScriptRef> scriptRefs = [];
 
-      int index = stack.frames.length;
       frames = stack.frames.map((Frame frame) {
         scriptRefs.add(frame.location.script);
-        ObservatoryFrame obsFrame = new ObservatoryFrame(this, frame, index--);
+        ObservatoryFrame obsFrame = new ObservatoryFrame(this, frame);
         obsFrame.locals = new List.from(
           frame.vars.map((v) => new ObservatoryVariable(this, v))
         );
@@ -608,13 +607,12 @@ class ObservatoryIsolate extends DebugIsolate {
 class ObservatoryFrame extends DebugFrame {
   final ObservatoryIsolate isolate;
   final Frame frame;
-  final int frameIndex;
 
   List<DebugVariable> locals;
 
   ObservatoryLocation _location;
 
-  ObservatoryFrame(this.isolate, this.frame, this.frameIndex);
+  ObservatoryFrame(this.isolate, this.frame);
 
   String get title => printFunctionNameRecursive(frame.function);
 


### PR DESCRIPTION
- drop frame numbers from the debugger ui (fix https://github.com/flutter/flutter/issues/4062)

@danrubel 

<img width="307" alt="screen shot 2016-05-19 at 9 19 20 pm" src="https://cloud.githubusercontent.com/assets/1269969/15417168/a36ad5b4-1e07-11e6-9090-4ef7f4a09d43.png">
