### PR TITLE
fix completions for import/show statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # dartlang plugin changelog
 
+## unreleased
+- fix completions for import/show statements
+
 ## 0.6.22
 - changed how we launch Flutter apps to speed up the edit/refresh development cycle
 - made the console output take up slightly less vertical space

--- a/lib/analysis/completions.dart
+++ b/lib/analysis/completions.dart
@@ -11,9 +11,11 @@ import 'analysis_server_lib.dart' show CompletionResults, CompletionSuggestion,
 
 final Logger _logger = new Logger('completions');
 
+const CompletionSuggestionKind_IDENTIFIER = 'IDENTIFIER';
+
 class DartAutocompleteProvider extends AutocompleteProvider {
   static const _suggestionKindMap = const <String, String>{
-    'IDENTIFIER': 'identifier',
+    CompletionSuggestionKind_IDENTIFIER: 'identifier',
     'IMPORT': 'import',
     'KEYWORD': 'keyword',
     'PARAMETER': 'property',
@@ -134,9 +136,10 @@ class DartAutocompleteProvider extends AutocompleteProvider {
     if (cs.parameterNames != null) {
       // If it takes no parameters, then just append `()`.
       if (cs.parameterNames.isEmpty) {
-        text += '()';
+        if (cs.kind != CompletionSuggestionKind_IDENTIFIER) {
+          text += '()';
+        }
       } else {
-        text = null;
 
         // If it has required params, then use a snippet: func(${1:arg}).
         int count = 0;
@@ -151,7 +154,10 @@ class DartAutocompleteProvider extends AutocompleteProvider {
           displayText = _describe(cs, useDocs: false);
         }
 
-        snippet = '${cs.completion}($names)\$${++count}';
+        if (cs.kind != CompletionSuggestionKind_IDENTIFIER) {
+          text = null;
+          snippet = '${cs.completion}($names)\$${++count}';
+        }
       }
     }
 


### PR DESCRIPTION
When suggesting completions for
```
import '/a/path/to/myfile.dart' show ^
```
we were correctly suggesting top level functions, but incorrectly inserting parameters for those top level functions when we should only be inserting the identifier for the top level function. This change prevents parameters from being inserted when only an identifier should be inserted.
@devoncarew 