### PR TITLE
fix an issue with newly created launches

### DIFF
--- a/lib/launch/launch_configs.dart
+++ b/lib/launch/launch_configs.dart
@@ -259,11 +259,13 @@ class LaunchConfiguration {
   }
 
   void reparse([String contents]) {
-    try {
-      var parsed = loadYaml(contents == null ? _file.readSync(true) : contents);
-      _map = parsed is Map ? parsed : {};
-    } catch (e) {
-      _map = {};
+    if (contents != null || _file.existsSync()) {
+      try {
+        var parsed = loadYaml(contents == null ? _file.readSync(true) : contents);
+        _map = parsed is Map ? parsed : {};
+      } catch (e) {
+        _map = {};
+      }
     }
   }
 }
@@ -305,7 +307,6 @@ class _ProjectConfigurations implements Disposable {
     } else {
       file.create().then((_) {
         file.writeSync(contents);
-
         _listenToLaunchDir();
       });
     }

--- a/lib/launch/run.dart
+++ b/lib/launch/run.dart
@@ -138,6 +138,8 @@ class RunApplicationManager implements Disposable, ContextMenuContributor {
 
   void run(LaunchConfiguration config) {
     _preLaunch();
+
+    // Make sure we're running with the latest config file info.
     config.reparse();
 
     _logger.info("Launching '${config}'.");


### PR DESCRIPTION
Fix an issue - newly created launches would fail with the message `no handler for launch type ‘null’ found`. We were trying to parse the file before it had been created on disk.

@danrubel 