### PR TITLE
optionally enable reload sources when starting an app

### DIFF
--- a/lib/flutter/flutter_daemon.dart
+++ b/lib/flutter/flutter_daemon.dart
@@ -373,7 +373,8 @@ class AppDomain extends Domain {
     bool startPaused,
     String route,
     String mode,
-    String target
+    String target,
+    bool reloadSources
   }) {
     return _call('app.start', _stripNullValues({
       'deviceId': deviceId,
@@ -381,7 +382,8 @@ class AppDomain extends Domain {
       'startPaused': startPaused,
       'route': route,
       'mode': mode,
-      'target': target
+      'target': target,
+      'reload-sources': reloadSources
     })).then((result) {
       return new AppStartedResult(result);
     });

--- a/lib/flutter/flutter_launch.dart
+++ b/lib/flutter/flutter_launch.dart
@@ -193,7 +193,8 @@ class _RunLaunchInstance extends _LaunchInstance {
       mode: _mode.name,
       startPaused: _mode.startPaused,
       target: _target,
-      route: _route
+      route: _route,
+      reloadSources: atom.config.getValue('flutter.reloadSources')
     ).then((AppStartedResult result) {
       _app = daemon.app.createDaemonApp(result.appId, supportsRestart: result.supportsRestart);
       _launch.app = _app;


### PR DESCRIPTION
Optionally enable reload sources when starting an app. The flutter devices that support this command will response with a `supportsRestart` property in their app started event.

@danrubel 