### PR TITLE
Add Configuration Options For Max Warnings Per File and Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # dartlang plugin changelog
 
+## unreleased
+- make max issues per file and project configurable.
+
 ## 0.6.45
 - disabled the outline view on Atom versions 1.13.0 and greater (it will need to
   be re-written to not use shadow DOM)

--- a/lib/linter.dart
+++ b/lib/linter.dart
@@ -75,8 +75,8 @@ class DartLinterProvider extends LinterProvider {
   Future<List<LintMessage>> lint(TextEditor editor) => new Future.value([]);
 }
 
-const int _maxIssuesPerFile = 200;
-const int _maxIssuesPerProject = 500;
+int get _maxIssuesPerFile => atom.config.getValue('$pluginId.maxIssuesPerFile');
+int get _maxIssuesPerProject => atom.config.getValue('$pluginId.maxIssuesPerProject');
 
 StreamController<List<AnalysisError>> _processedErrorsController = new StreamController.broadcast();
 

--- a/lib/plugin.dart
+++ b/lib/plugin.dart
@@ -374,6 +374,21 @@ class AtomDartPackage extends AtomPackage {
         'order': 12
       },
 
+      // issues
+      'maxIssuesPerProject': {
+        'title': 'Max number of issues displayed per prject',
+        'type': 'integer',
+        'default': 500,
+        'order': 13
+      },
+
+      'maxIssuesPerFile': {
+        'title': 'Max number of issues displayed per file',
+        'type': 'integer',
+        'default': 200,
+        'order': 14
+      },
+
       // experimental features
       // TODO(devoncarew): This option needs some debugging; see #931.
       'formatOnSave': {
@@ -381,7 +396,7 @@ class AtomDartPackage extends AtomPackage {
         'description': 'Format the current editor on save. Note: this does not work well with Atom\'s autosave feature.',
         'type': 'boolean',
         'default': false,
-        'order': 13
+        'order': 15
       }
     };
   }


### PR DESCRIPTION
> Proposed solution for https://github.com/dart-atom/dartlang/issues/940.
## How It Was Fixed:
- Add configuration  options for `maxIssuesPerFile` and `maxIssuesPerProject`.
  - Had to bump the `order` of the options after that.
- Change the `const` variables `_maxIssuesPerFile` and `_maxIssuesPerProject` to be getters.
  - They can no longer be `const` because they can be updated.
  - Use the values from the configuration options in the getters.
## Testing Suggestions:
- Pull down this branch:
  - See that you can change the max issues displayed per project and file.
  - Change them.
  - Run `Reanalyze Sources`
  - Create enough errors that they get truncated by the max values.
  - See that get get truncated at the provided values.

FYA: @devoncarew 