### PR TITLE
Use the Indie Linter V2 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
         "^1.0.0": "consumeToolbar"
       }
     },
+    "linter-indie": {
+      "versions": {
+        "2.0.0": "consumeIndie"
+      }
+    },
     "linter-plus-self": {
       "versions": {
         "0.1.0": "consumeLinter"


### PR DESCRIPTION
> Proposed solution for https://github.com/dart-atom/dartlang/issues/1118

## Problem
With the recent upgrade to the linter package lints stopped showing up in the IDE.

## Solution
- Use the Indie Linter V2 API

## Notes
- This makes it so two lint panels exist. Should this be removed in a follow up PR?
![image](https://cloud.githubusercontent.com/assets/12398382/23981514/5b430f0a-09c4-11e7-90ad-73d2dc7fb4f0.png)
- I keep getting a error when I views to a different dart file. I am not sure if this is something I did. Or if this is the same dart2js issue noted [here](https://github.com/dart-atom/dartlang/pull/1111#issuecomment-282565397)

```
TypeError: this.obj.callMethod$2 is not a function
    at EventListener$3 (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:49942:18)
    at undefined.EventListener$ (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:49948:14)
    at NavigationHelper.dart.NavigationHelper._activate$1 (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:51939:33)
    at $constructor.<anonymous> (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:29979:32)
    at _RootZone.runUnaryGuarded$2 (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:35064:20)
    at _BroadcastSubscription._sendData$1 (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:34371:20)
    at _DelayedData.perform$1 (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:34528:18)
    at _PendingEvents_schedule_closure.dart._PendingEvents_schedule_closure.call$0 (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:34582:16)
    at undefined._microtaskLoop (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:32436:27)
    at $constructor.dart._startMicrotaskLoop (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:32442:11)
    at TimerImpl_internalCallback0.dart.TimerImpl_internalCallback0.call$0 (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:29038:23)
    at invokeClosure_closure.call$0 (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:30926:29)
    at _IsolateContext.eval$1 (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:28658:25)
    at undefined._callInIsolate (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:28302:28)
    at dart.invokeClosure (/Users/jacehensley/workspaces/dartlang/web/entry.dart.js:29879:20)
    at /Users/jacehensley/workspaces/dartlang/web/entry.dart.js:29900:18
```

## Questions
- Should I rip out the existing self-API related things (what I deprecated)?
  - If I did this should probably go into a breaking change release, not sure if wanted that.

FYA: @devoncarew 