### PR TITLE
rev to 0.6.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dartlang plugin changelog
 
-## 0.6.49
+## 0.7.0
 - removed the Dart errors view in favor of using the Linter's default UI
 - some fixes to the outline view's styles
 - updated view management to use atom's docks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # dartlang plugin changelog
 
-## unreleased
+## 0.6.49
 - removed the Dart errors view in favor of using the Linter's default UI
 - some fixes to the outline view's styles
-- redo custom view management to use atom docks
+- updated view management to use atom's docks
 - fixed rename
 
 ## 0.6.48

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: atom_dartlang
-version: 0.6.49
+version: 0.7.0
 description: A Dart plugin for Atom.
 homepage: https://github.com/dart-atom/dartlang
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: atom_dartlang
-version: 0.6.48
+version: 0.6.49
 description: A Dart plugin for Atom.
 homepage: https://github.com/dart-atom/dartlang
 


### PR DESCRIPTION
@cdavidjean - this updates the version to `0.6.49` in order to release the recent changes:

- removed the Dart errors view in favor of using the Linter's default UI
- some fixes to the outline view's styles
- updated view management to use atom's docks
- fixed rename

given the scope of the changes, we may instead want to rev to `0.7.0`; thoughts?
